### PR TITLE
Adding more tests to upstream

### DIFF
--- a/clevis/Regression/generate-initramfs/Makefile
+++ b/clevis/Regression/generate-initramfs/Makefile
@@ -1,0 +1,64 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Regression/generate-initramfs
+#   Description: Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed.
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Regression/generate-initramfs
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Martin Zeleny <mzeleny@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed." >> $(METADATA)
+	@echo "Type:            Regression" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis-dracut" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1648004" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHEL6 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Regression/generate-initramfs/PURPOSE
+++ b/clevis/Regression/generate-initramfs/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Regression/generate-initramfs
+Description: Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed.
+Author: Martin Zeleny <mzeleny@redhat.com>

--- a/clevis/Regression/generate-initramfs/main.fmf
+++ b/clevis/Regression/generate-initramfs/main.fmf
@@ -1,0 +1,25 @@
+summary: Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed.
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis-dracut
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- SP-TBU
+- TIPfail_Security
+- Tier1
+- Tier1security
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5, rhel-6: False
+extra-summary: /CoreOS/clevis/Regression/generate-initramfs
+extra-task: /CoreOS/clevis/Regression/generate-initramfs
+extra-nitrate: TC#0589758

--- a/clevis/Regression/generate-initramfs/runtest.sh
+++ b/clevis/Regression/generate-initramfs/runtest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Regression/generate-initramfs
+#   Description: Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed.
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} ${PACKAGE}-luks"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+    rlPhaseEnd
+
+    rlPhaseStartTest "Overwrite existing initramfs file"
+        rlRun -s "dracut -f" 0 "Try to generate initramfs"
+        rlAssertNotGrep "ERROR|FAILED" ${rlRun_LOG} -E
+        rlRun "rm ${rlRun_LOG}"
+    rlPhaseEnd
+
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/automate-clevis-luks-bind/Makefile
+++ b/clevis/Sanity/automate-clevis-luks-bind/Makefile
@@ -1,0 +1,66 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Sanity/automate-clevis-luks-bind
+#   Description: This test validates the newly added -y (assume-yes)
+#   parameter that helps automate clevis luks bind
+#
+#   Author: Sergio Correia <scorreia@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Sanity/automate-clevis-luks-bind
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Sergio Correia <scorreia@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     This test validates the newly added -y (assume-yes) parameter that helps automate clevis luks bind" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang cryptsetup" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1819767" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHEL6 -RHEL7 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Sanity/automate-clevis-luks-bind/PURPOSE
+++ b/clevis/Sanity/automate-clevis-luks-bind/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/automate-clevis-luks-bind
+Description: This test validates the newly added -y (assume-yes) parameter that helps automate clevis luks bind
+Author: Sergio Correia <scorreia@redhat.com>

--- a/clevis/Sanity/automate-clevis-luks-bind/main.fmf
+++ b/clevis/Sanity/automate-clevis-luks-bind/main.fmf
@@ -1,0 +1,30 @@
+summary: This test validates the newly added -y (assume-yes) parameter that helps
+    automate clevis luks bind
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- clevis-luks
+- tang
+- cryptsetup
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- NoRHEL7
+- SP-TBU
+- TIPpass
+- Tier1
+tier: '1'
+relevancy: |
+    distro < rhel-8: False
+    distro = rhel-alt-7: False
+extra-summary: /CoreOS/clevis/Sanity/automate-clevis-luks-bind
+extra-task: /CoreOS/clevis/Sanity/automate-clevis-luks-bind
+extra-nitrate: TC#0607316

--- a/clevis/Sanity/automate-clevis-luks-bind/runtest.sh
+++ b/clevis/Sanity/automate-clevis-luks-bind/runtest.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/automate-clevis-luks-bind
+#   Description: This test validates the newly added -y (assume-yes)
+#   parameter that helps automate clevis luks bind
+#
+#   Author: Sergio Correia <scorreia@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} ${PACKAGE}-luks tang cryptsetup"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd ${TmpDir}"
+
+        rlRun "dd if=/dev/zero of=loopfile1 bs=100M count=1"
+        rlRun "dd if=/dev/zero of=loopfile2 bs=100M count=1"
+
+        rlRun "luks1=\$(losetup -f --show loopfile1)" 0 "Create device from file (loopfile1)"
+        rlRun "luks2=\$(losetup -f --show loopfile2)" 0 "Create device from file (loopfile2)"
+
+        rlRun "pass=redhat123"
+        rlRun "cryptsetup luksFormat --type luks1 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode --force-password ${luks1} <<< ${pass}"
+        rlRun "cryptsetup luksFormat --type luks2 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode --force-password ${luks2} <<< ${pass}"
+
+        rlRun "rlServiceStart tangd.socket"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Automate bind using tang pin"
+        for d in ${luks1} ${luks2}; do
+            rlRun "slot=3"
+            cfg='{"url":"localhost"}'
+            rlRun "clevis luks bind -y -d ${d} -s ${slot} tang '${cfg}' <<< ${pass}" 0 "clevis luks bind - ${d}:${slot}"
+            rlRun "clevis luks unlock -d ${d}" 0 "clevis luks unlock - ${d}"
+            rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+            rlRun "clevis luks unbind -f -d ${d} -s ${slot}" 0 "clevis luks unbind - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Automate bind using sss pin"
+        for d in ${luks1} ${luks2}; do
+            rlRun "slot=5"
+            cfg='{"t":2,"pins":{"tang":[{"url":"localhost"},{"url":"localhost"}]}}'
+            rlRun "clevis luks bind -y -d ${d} -s ${slot} sss '${cfg}' <<< ${pass}" 0 "clevis luks bind - ${d}:${slot}"
+            rlRun "clevis luks unlock -d ${d}" 0 "clevis luks unlock - ${d}"
+            rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+            rlRun "clevis luks unbind -f -d ${d} -s ${slot}" 0 "clevis luks unbind - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rlServiceRestore tangd.socket"
+        rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+        rlRun "losetup -d ${luks1}"
+        rlRun "losetup -d ${luks2}"
+        rlRun "popd"
+        rlRun "rm -r ${TmpDir}" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/bind-luks/Makefile
+++ b/clevis/Sanity/bind-luks/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/clevis/Sanity/bind-luks
+#   Description: uses LUKS block device to test clevis luksmeta binding
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/clevis/Sanity/bind-luks
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,16 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
-	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "Description:     uses LUKS block device to test clevis luksmeta binding" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis tang jose" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks luksmeta tang expect socat psmisc wget" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
+	@echo "Bug:             1623867" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/clevis/Sanity/bind-luks/PURPOSE
+++ b/clevis/Sanity/bind-luks/PURPOSE
@@ -1,0 +1,9 @@
+PURPOSE of /CoreOS/clevis/Sanity/bind-luks
+Description: uses LUKS block device to test clevis luksmeta binding
+Author: Jiri Jaburek <jjaburek@redhat.com>
+
+NOTE: This test ***does not*** verify that clevis can decrypt the
+bound LUKS volumes, as this code is only present in the dracut plugin.
+Instead, this test tries many combinations of interactive/batch and
+other features of bind-luks, and another test uses one of these methods
+to test the dracut-based decryption.

--- a/clevis/Sanity/bind-luks/main.fmf
+++ b/clevis/Sanity/bind-luks/main.fmf
@@ -1,0 +1,38 @@
+summary: uses LUKS block device to test clevis luksmeta binding
+description: |
+    NOTE: This test ***does not*** verify that clevis can decrypt the
+    bound LUKS volumes, as this code is only present in the dracut plugin.
+    Instead, this test tries many combinations of interactive/batch and
+    other features of bind-luks, and another test uses one of these methods
+    to test the dracut-based decryption.
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- tang
+- clevis
+- jose
+test: ./runtest.sh
+recommend:
+- clevis
+- clevis-luks
+- luksmeta
+- tang
+- expect
+- socat
+- psmisc
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPpass_Security
+- Tier1
+- Tier1security
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5, rhel-6: False
+extra-summary: /CoreOS/clevis/Sanity/bind-luks
+extra-task: /CoreOS/clevis/Sanity/bind-luks
+extra-nitrate: TC#0554056

--- a/clevis/Sanity/bind-luks/runtest.sh
+++ b/clevis/Sanity/bind-luks/runtest.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/bind-luks
+#   Description: uses LUKS block device to test clevis luksmeta binding
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+legacy_tang() {
+    test -x /usr/libexec/tangd-update
+}
+gen_tang_keys() {
+    rlRun "jose jwk gen -i '{\"alg\":\"ES512\"}' -o \"$1/sig.jwk\""
+    rlRun "jose jwk gen -i '{\"alg\":\"ECMR\"}' -o \"$1/exc.jwk\""
+}
+gen_tang_cache() {
+    rlRun "/usr/libexec/tangd-update \"$1\" \"$2\""
+}
+grep_b64() {
+    rlRun "jose b64 dec -i \"$2\" -O - | grep -q \"$1\"" 0 \
+        "File '$2' should contain '$1' when b64-decrypted" || \
+            jose b64 dec -i "$2" -O -
+}
+start_tang() {
+    local i= cache="$1" port="$2"
+    if [ -z "$port" ]; then
+        for i in {8000..8999}; do
+            if ! fuser -s -n tcp "$i"; then
+                port="$i"
+                break
+            fi
+        done
+    fi
+    if [ -z "$port" ] || fuser -s -n tcp "$port"; then
+        rlLogFatal "no free port found for tangd: $port" 1>&2
+        return 1
+    fi
+    nohup socat "tcp-listen:$port,fork" exec:"/usr/libexec/tangd $cache" >/dev/null &
+    local pid=$!
+    rlWaitForSocket "$port" -p "$pid"
+    rlLogInfo "started tangd $cache as pid $pid on port $port" 1>&2
+    [ ! -t 1 ] && echo "$port"
+    return 0
+}
+stop_tang() {
+    rlRun "fuser -s -k \"$1/tcp\""
+}
+
+luks_setup() {
+    rlPhaseStart FAIL "cryptsetup setup"
+        rlRun "dd if=/dev/zero of=loopfile bs=100M count=1"
+        rlRun "lodev=\$(losetup -f --show loopfile)"
+        echo -n redhat123 > pwfile
+        rlRun "cryptsetup luksFormat --batch-mode --key-file pwfile \"$lodev\""
+    rlPhaseEnd
+}
+luks_destroy() {
+    rlPhaseStart FAIL "cryptsetup destroy"
+        rlRun "losetup -d \"$lodev\""
+        rlRun "rm -f loopfile pwfile"
+    rlPhaseEnd
+}
+
+
+PACKAGE="clevis"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "tangd setup"
+        if legacy_tang; then
+            rlRun "mkdir -p tangd/db tangd/cache"
+            gen_tang_keys "tangd/db"
+            gen_tang_cache "tangd/db" "tangd/cache"
+            port=$(start_tang "tangd/cache")
+        else
+            rlRun "mkdir -p tangd/db"
+            gen_tang_keys "tangd/db"
+            port=$(start_tang "tangd/db")
+        fi
+    rlPhaseEnd
+
+    luks_setup
+
+    rlPhaseStart FAIL "clevis bind-luks, confirmed interactively"
+        if rlIsRHEL '<8'; then
+            [ -z "$(luksmeta show -d "$lodev" -s 1)" ] || rlFail "existing luksmeta data found in slot 1"
+        fi
+
+        expect <<CLEVIS_END
+            set timeout 60
+            spawn sh -c "clevis luks bind -d $lodev tang '{ \"url\": \"http://localhost:$port\" }'"
+            expect {
+                {*Do you wish to trust these keys} {send y\\r; exp_continue}
+                {*Do you wish to initialize} {send y\\r; exp_continue}
+                {*Enter existing LUKS password} {send redhat123\\r}
+            }
+            expect eof
+            exit [lindex [wait] 3]
+CLEVIS_END
+        rlAssert0 "expect spawning clevis" $?
+
+        if rlIsRHEL '<8'; then
+            [ "$(luksmeta show -d "$lodev" -s 1)" ] || rlFail "no luksmeta data found in slot 1"
+        fi
+    rlPhaseEnd
+
+    luks_destroy
+    luks_setup
+
+    rlPhaseStart FAIL "clevis bind-luks, batch mode"
+        rlRun "thp=\$(jose jwk thp -i tangd/db/sig.jwk)"
+
+        if rlIsRHEL '<8'; then
+            [ -z "$(luksmeta show -d "$lodev" -s 1)" ] || rlFail "existing luksmeta data found in slot 1"
+        fi
+
+        rlRun "clevis luks bind -f -k pwfile -d \"$lodev\" tang '{ \"url\": \"http://localhost:$port\", \"thp\": \"$thp\" }'" 0
+
+        if rlIsRHEL '<8'; then
+            [ "$(luksmeta show -d "$lodev" -s 1)" ] || rlFail "no luksmeta data found in slot 1"
+        fi
+    rlPhaseEnd
+
+    luks_destroy
+
+    rlPhaseStartCleanup
+        stop_tang "$port"
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/luks-edit/Makefile
+++ b/clevis/Sanity/luks-edit/Makefile
@@ -1,0 +1,64 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Sanity/luks-edit
+#   Description: Tests for the clevis luks edit command
+#   Author: Sergio Correia <scorreia@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Sanity/luks-edit
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Sergio Correia <scorreia@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Tests for the clevis luks edit command" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        10m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1436735" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHEL6 -RHEL7 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Sanity/luks-edit/PURPOSE
+++ b/clevis/Sanity/luks-edit/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/luks-edit
+Description: Tests for the clevis luks edit command
+Author: Sergio Correia <scorreia@redhat.com>

--- a/clevis/Sanity/luks-edit/main.fmf
+++ b/clevis/Sanity/luks-edit/main.fmf
@@ -1,0 +1,29 @@
+summary: Tests for the clevis luks edit command
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- clevis-luks
+- tang
+duration: 10m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- NoRHEL7
+- SP-TBU
+- TIPpass
+- Tier1
+tier: '1'
+relevancy: |
+    distro < rhel-8: False
+    distro < rhel-8.2: False
+    distro = rhel-alt-7: False
+extra-summary: /CoreOS/clevis/Sanity/luks-edit
+extra-task: /CoreOS/clevis/Sanity/luks-edit
+extra-nitrate: TC#0607353

--- a/clevis/Sanity/luks-edit/runtest.sh
+++ b/clevis/Sanity/luks-edit/runtest.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/luks-edit
+#   Description: Tests for the clevis luks edit command
+#   Author: Sergio Correia <scorreia@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} ${PACKAGE}-luks tang"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd ${TmpDir}"
+
+        rlRun "dd if=/dev/zero of=loopfile1 bs=100M count=1"
+        rlRun "dd if=/dev/zero of=loopfile2 bs=100M count=1"
+
+        rlRun "luks1=\$(losetup -f --show loopfile1)" 0 "Create device from file (loopfile1)"
+        rlRun "luks2=\$(losetup -f --show loopfile2)" 0 "Create device from file (loopfile2)"
+
+        rlRun "pass=redhat123"
+        rlRun "cryptsetup luksFormat --type luks1 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode --force-password ${luks1} <<< ${pass}"
+        rlRun "cryptsetup luksFormat --type luks2 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode --force-password ${luks2} <<< ${pass}"
+
+        rlRun "rlServiceStart tangd.socket"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Bind slot 3 with tang for the next tests"
+        rlRun "slot=3"
+        cfg='{"url":"localhost"}'
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks bind -y -d ${d} -s ${slot} tang '${cfg}' <<< ${pass}" 0 "clevis luks bind tang - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Try the same config"
+        cfg='{"url":"localhost"}'
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 1 "clevis luks edit should fail with the same config - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Try an invalid configuration"
+        cfg='{"url&:"localhost"}'
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 1 "clevis luks edit should fail with invalid JSON - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Change the tang url"
+        cfg='{"url":"http://localhost"}'
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 0 "clevis luks edit change tang url - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Unbind slot 3 - end of tang tests"
+        rlRun "slot=3"
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks unbind -f -d ${d} -s ${slot} <<< ${pass}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Bind slot 4 with sss for the next tests"
+        rlRun "slot=4"
+        cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"}]}}' "localhost")
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks bind -y -d ${d} -s ${slot} sss '${cfg}' <<< ${pass}" 0 "clevis luks bind sss - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add a new tang server to the sss config"
+        cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' "localhost" "localhost")
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 0 "clevis luks edit add tang server to sss - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Edit one of the servers in the sss pin"
+        cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' "http://localhost" "localhost")
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 0 "clevis luks edit tang server in sss - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Change threshold to 2"
+        cfg=$(printf '{"t":2,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' "localhost" "localhost")
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 0 "clevis luks edit change threshold to 2 - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Change threshold to 3 - broken config"
+        cfg=$(printf '{"t":3,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' "localhost" "localhost")
+        for d in ${luks1} ${luks2}; do
+            rlRun "clevis luks edit -d ${d} -s ${slot} -c '${cfg}'" 1 "clevis luks edit change threshold to 3 - broken - ${d}:${slot}"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rlServiceRestore tangd.socket"
+        rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+        rlRun "losetup -d ${luks1}"
+        rlRun "losetup -d ${luks2}"
+        rlRun "popd"
+        rlRun "rm -r ${TmpDir}" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/luks-list/Makefile
+++ b/clevis/Sanity/luks-list/Makefile
@@ -1,0 +1,64 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Sanity/luks-list
+#   Description: Sanity check for listing PBD policies and check proper failing message
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Sanity/luks-list
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Martin Zeleny <mzeleny@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Sanity check for listing PBD policies and check proper failing message" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang wget" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1543380 1766526" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHEL6 -RHEL7 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Sanity/luks-list/PURPOSE
+++ b/clevis/Sanity/luks-list/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/luks-list
+Description: Sanity check for listing PBD policies and check proper failing message
+Author: Martin Zeleny <mzeleny@redhat.com>

--- a/clevis/Sanity/luks-list/main.fmf
+++ b/clevis/Sanity/luks-list/main.fmf
@@ -1,0 +1,30 @@
+summary: Sanity check for listing PBD policies and check proper failing message
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- clevis-luks
+- tang
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- NoRHEL7
+- SP-TBU
+- TIPpass
+- TIPpass_Security
+- Tier1
+tier: '1'
+relevancy: |
+    distro < rhel-8: False
+    distro < rhel-8.2: False
+extra-summary: /CoreOS/clevis/Sanity/luks-list
+extra-task: /CoreOS/clevis/Sanity/luks-list
+extra-nitrate: TC#0605260

--- a/clevis/Sanity/luks-list/runtest.sh
+++ b/clevis/Sanity/luks-list/runtest.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/luks-list
+#   Description: Sanity check for listing PBD policies and check proper failing message
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} ${PACKAGE}-luks tang cryptsetup"
+FMT="%{name}-%{version}-%{release}\n"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+        rlRun "packageVersion=$(rpm -q ${PACKAGE} --qf ${FMT})"
+        rlTestVersion "${packageVersion}" '>=' 'clevis-11-5' \
+            || rlDie "Tested functionality is not in old version ${packageVersion}"
+        rlLogInfo "Sufficient version ${packageVersion} for running the test."
+
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+
+        rlRun "dd if=/dev/zero of=loopfile bs=100M count=1"
+        rlRun "lodev=\$(losetup -f --show loopfile)" 0 "Create device from file"
+        rlRun "echo -n redhat123 | cryptsetup luksFormat --batch-mode --key-file - ${lodev}"
+
+        rlRun "rlServiceStart tangd.socket"
+    rlPhaseEnd
+
+
+    rlPhaseStartTest "Check for proper failing message (BZ#1543380)"
+        rlRun -s "clevis luks bind -d ${lodev} wrongPin '{}'" "1-127" "Run with wrong pin"
+        rlAssertGrep "'wrongPin' is not a valid pin!" $rlRun_LOG
+        rm $rlRun_LOG
+
+        rlRun -s "clevis luks bind -d ${lodev} wrongPin" "1-127" "Run with wrong pin and missing pin config"
+        rlAssertGrep "'wrongPin' is not a valid pin!" $rlRun_LOG
+        rm $rlRun_LOG
+
+        rlRun -s "clevis luks bind -d ${lodev} tang" "1-127" "Run with good pin, but missing pin config"
+        rlAssertGrep "Did not specify a pin config!" $rlRun_LOG
+        rm $rlRun_LOG
+    rlPhaseEnd
+
+
+    rlPhaseStartTest "clevis luks bind"
+        rlRun "luksmeta show -d ${lodev} -s 1" "1-100" "Check if there is no luksmeta data in slot 1"
+        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+
+        rlRun  "echo -n redhat123 | clevis luks bind -f -k - -d ${lodev} tang '{ \"url\": \"http://localhost\", \"adv\": \"adv.json\" }'" 0 "clevis luks bind"
+
+        if rlIsRHEL '<8'; then
+            rlRun "luksmeta show -d ${lodev} -s 1" 0 "Check if there are luksmeta data in slot 1"
+        fi
+
+        rlRun -s "lsblk" 0 "Encrypted LUKS volume is not visible"
+        rlAssertNotGrep "crypt" $rlRun_LOG
+        rm $rlRun_LOG
+
+        rlRun "clevis luks unlock -d ${lodev}" 0 "Automatic unlock device"
+
+        rlRun -s "lsblk" 0 "Encrypted LUKS volume is visible"
+        rlAssertGrep "crypt" $rlRun_LOG
+        rm $rlRun_LOG
+    rlPhaseEnd
+
+
+    rlPhaseStartTest "Listing PBD policies by 'clevis luks list' (BZ#1766526)"
+        rlRun -s "clevis luks list -d ${lodev}" 0 "Listing PBD policies"
+        rlLog "Check presence of tang pin and localhost url in config"
+        rlAssertGrep "tang" $rlRun_LOG
+        rlAssertGrep "http://localhost" $rlRun_LOG
+        rm $rlRun_LOG
+    rlPhaseEnd
+
+
+    rlPhaseStartCleanup
+        rlRun "rlServiceRestore tangd.socket"
+        rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+        rlRun "losetup -d ${lodev}"
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/luks-pass/Makefile
+++ b/clevis/Sanity/luks-pass/Makefile
@@ -1,0 +1,64 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Sanity/luks-pass
+#   Description: Test the 'clevis luks pass' subcommand with the device and slot as a parameter and check the passphrase used to bind that particular slot.
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Sanity/luks-pass
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Martin Zeleny <mzeleny@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Test the 'clevis luks pass' subcommand with the device and slot as a parameter and check the passphrase used to bind that particular slot." >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang jose cryptsetup wget" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1436780" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHEL6 -RHEL7 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Sanity/luks-pass/PURPOSE
+++ b/clevis/Sanity/luks-pass/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/luks-pass
+Description: Test the 'clevis luks pass' subcommand with the device and slot as a parameter and check the passphrase used to bind that particular slot.
+Author: Martin Zeleny <mzeleny@redhat.com>

--- a/clevis/Sanity/luks-pass/main.fmf
+++ b/clevis/Sanity/luks-pass/main.fmf
@@ -1,0 +1,33 @@
+summary: Test the 'clevis luks pass' subcommand with the device and slot as a parameter
+    and check the passphrase used to bind that particular slot.
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- clevis-luks
+- tang
+- jose
+- cryptsetup
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- NoRHEL7
+- SP-TBU
+- TIPpass
+- TIPpass_Security
+- Tier1
+tier: '1'
+relevancy: |
+    distro < rhel-8: False
+    distro < rhel-8.2: False
+extra-summary: /CoreOS/clevis/Sanity/luks-pass
+extra-task: /CoreOS/clevis/Sanity/luks-pass
+extra-nitrate: TC#0605163

--- a/clevis/Sanity/luks-pass/runtest.sh
+++ b/clevis/Sanity/luks-pass/runtest.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/luks-pass
+#   Description: Test the 'clevis luks pass' subcommand with the device and slot as a parameter and check the passphrase used to bind that particular slot.
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} ${PACKAGE}-luks tang jose luksmeta cryptsetup"
+FMT="%{name}-%{version}-%{release}\n"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+        rlRun "packageVersion=$(rpm -q ${PACKAGE} --qf ${FMT})"
+        rlTestVersion "${packageVersion}" '>=' 'clevis-11-5' \
+            || rlDie "Tested functionality is not in old version ${packageVersion}"
+        rlLogInfo "Sufficient version ${packageVersion} for running the test."
+
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+
+        rlRun "dd if=/dev/zero of=loopfile bs=100M count=1"
+        rlRun "lodev=\$(losetup -f --show loopfile)" 0 "Create device from file"
+        rlRun "echo -n redhat123 | cryptsetup luksFormat --batch-mode --key-file - ${lodev}"
+
+        rlRun "rlServiceStart tangd.socket"
+    rlPhaseEnd
+
+    rlPhaseStartTest "clevis luks bind"
+        rlRun "luksmeta show -d ${lodev} -s 1" "1-100" "Check if there is no luksmeta data in slot 1"
+        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+
+        rlRun  "echo -n redhat123 | clevis luks bind -f -k - -d ${lodev} tang '{ \"url\": \"http://localhost\", \"adv\": \"adv.json\" }'" 0 "clevis luks bind"
+
+        if rlIsRHEL '<8'; then
+            rlRun "luksmeta show -d ${lodev} -s 1" 0 "Check if there are luksmeta data in slot 1"
+        fi
+
+        rlRun -s "lsblk" 0 "Encrypted LUKS volume is not visible"
+        rlAssertNotGrep "crypt" $rlRun_LOG
+        rm $rlRun_LOG
+
+        rlRun "clevis luks pass -d ${lodev} -s 1 > luksPass" 0 "extract luks passphrase"
+        rlRun "cat luksPass"
+        rlRun "cryptsetup open ${lodev} luks_bz1436780 --key-file luksPass" 0 "Open LUKS volume manually with extracted password"
+
+        rlRun -s "lsblk" 0 "Encrypted LUKS volume is visible"
+        rlAssertGrep "crypt" $rlRun_LOG
+        rm $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rlServiceRestore tangd.socket"
+        rlRun "find /dev/mapper -name 'luks*' -exec cryptsetup close {} +"
+        rlRun "losetup -d ${lodev}"
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/pin-sss/Makefile
+++ b/clevis/Sanity/pin-sss/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/clevis/Sanity/pin-sss
+#   Description: tests the sss pin functionality of clevis
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/clevis/Sanity/pin-sss
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,15 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
-	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "Description:     tests the sss pin functionality of clevis" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis tang jose luksmeta" >> $(METADATA)
+	@echo "Requires:        clevis tang socat expect psmisc wget" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/clevis/Sanity/pin-sss/PURPOSE
+++ b/clevis/Sanity/pin-sss/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/pin-sss
+Description: tests the sss pin functionality of clevis
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/clevis/Sanity/pin-sss/main.fmf
+++ b/clevis/Sanity/pin-sss/main.fmf
@@ -1,0 +1,32 @@
+summary: tests the sss pin functionality of clevis
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- tang
+- clevis
+- jose
+test: ./runtest.sh
+recommend:
+- clevis
+- tang
+- socat
+- expect
+- psmisc
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPfail_Security
+- Tier1
+- Tier1security
+- TierCandidatesFAIL
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5, rhel-6: False
+extra-summary: /CoreOS/clevis/Sanity/pin-sss
+extra-task: /CoreOS/clevis/Sanity/pin-sss
+extra-nitrate: TC#0552029

--- a/clevis/Sanity/pin-sss/runtest.sh
+++ b/clevis/Sanity/pin-sss/runtest.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/pin-sss
+#   Description: tests the sss pin functionality of clevis
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# TODO: rewrite this test to use non-tang pins, possibly
+#       a local-key-file pin or something
+legacy_tang() {
+    test -x /usr/libexec/tangd-update
+}
+gen_tang_keys() {
+    rlRun "/usr/libexec/tangd-keygen \"$1\""
+}
+gen_tang_cache() {
+    rlRun "/usr/libexec/tangd-update \"$1\" \"$2\""
+}
+grep_b64() {
+    rlRun "jose b64 dec -i \"$2\" -O - | grep -q \"$1\"" 0 \
+        "File '$2' should contain '$1' when b64-decrypted" || \
+            jose b64 dec -i "$2" -O -
+}
+start_tang() {
+    local i= cache="$1" port="$2"
+    if [ -z "$port" ]; then
+        for i in {8020..8999}; do
+            if ! fuser -s -n tcp "$i"; then
+                port="$i"
+                break
+            fi
+        done
+    fi
+    if [ -z "$port" ] || fuser -s -n tcp "$port"; then
+        rlLogFatal "no free port found for tangd: $port" 1>&2
+        return 1
+    fi
+    nohup socat "tcp-listen:$port,fork" exec:"/usr/libexec/tangd $cache" >/dev/null &
+    local pid=$!
+    rlWaitForSocket "$port" -p "$pid"
+    rlLogInfo "started tangd $cache as pid $pid on port $port" 1>&2
+    [ ! -t 1 ] && echo "$port"
+    return 0
+}
+stop_tang() {
+    rlRun "fuser -s -k \"$1/tcp\""
+}
+
+
+PACKAGE="clevis"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "tangd setup"
+        if legacy_tang; then
+            rlRun "mkdir -p tangd/db{1,2,3} tangd/cache{1,2,3}"
+            gen_tang_keys "tangd/db1"
+            gen_tang_cache "tangd/db1" "tangd/cache1"
+            gen_tang_keys "tangd/db2"
+            gen_tang_cache "tangd/db2" "tangd/cache2"
+            gen_tang_keys "tangd/db3"
+            gen_tang_cache "tangd/db3" "tangd/cache3"
+            port1=$(start_tang "tangd/cache1")
+            port2=$(start_tang "tangd/cache2")
+            port3=$(start_tang "tangd/cache3")
+        else
+            rlRun "mkdir -p tangd/cache{1,2,3}"
+            gen_tang_keys "tangd/cache1"
+            gen_tang_keys "tangd/cache2"
+            gen_tang_keys "tangd/cache3"
+            port1=$(start_tang "tangd/cache1")
+            port2=$(start_tang "tangd/cache2")
+            port3=$(start_tang "tangd/cache3")
+        fi
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "Valid sss config with wrong tang config"
+        rlRun "wget -nv -O adv1.json \"http://localhost:$port1/adv\""
+        rlRun "wget -nv -O adv2.json \"http://localhost:$port2/adv\""
+        echo -n "testing data string" > plain
+        rlRun "clevis encrypt sss '{
+                \"t\": 2,
+                \"pins\": {
+                    \"tang\": [
+                        { \"url\": \"http://wronghost\", \"adv\": \"adv1.json\" },
+                        { \"url\": \"http://localhost:9999\", \"adv\": \"adv2.json\" },
+                        { \"url\": \"http://localhost:$port1\", \"adv\": \"nonexisting_file\" }
+                    ]
+                }
+            }' < plain > enc" 1 "Valid sss config with wrong tang config"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis setup, encrypt using t=2 and 3 servers"
+        rlRun "wget -nv -O adv1.json \"http://localhost:$port1/adv\""
+        rlRun "wget -nv -O adv2.json \"http://localhost:$port2/adv\""
+        rlRun "wget -nv -O adv3.json \"http://localhost:$port3/adv\""
+        echo -n "testing data string" > plain
+        rlRun "clevis encrypt sss '{
+                \"t\": 2,
+                \"pins\": {
+                    \"tang\": [
+                        { \"url\": \"http://localhost:$port1\", \"adv\": \"adv1.json\" },
+                        { \"url\": \"http://localhost:$port2\", \"adv\": \"adv2.json\" },
+                        { \"url\": \"http://localhost:$port3\", \"adv\": \"adv3.json\" }
+                    ]
+                }
+            }' < plain > enc" 0 "clevis setup, encrypt using t=2 and 3 servers"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis decrypt, all tang servers available"
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis decrypt, no servers available"
+        stop_tang "$port1"
+        stop_tang "$port2"
+        stop_tang "$port3"
+        rlRun "clevis decrypt < enc > plain2" 1
+        rlAssertDiffer plain plain2
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis decrypt, one server available"
+        start_tang "tangd/cache1" "$port1"
+        rlRun "clevis decrypt < enc > plain2" 1
+        rlAssertDiffer plain plain2
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis decrypt, two servers available"
+        start_tang "tangd/cache3" "$port3"
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        stop_tang "$port1"
+        #stop_tang "$port2"  # already down
+        stop_tang "$port3"
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/pin-tang/Makefile
+++ b/clevis/Sanity/pin-tang/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/clevis/Sanity/pin-tang
+#   Description: tests the tang pin functionality of clevis
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/clevis/Sanity/pin-tang
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,15 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
-	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "Description:     tests the tang pin functionality of clevis" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis tang jose luksmeta" >> $(METADATA)
+	@echo "Requires:        clevis tang socat expect psmisc wget" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/clevis/Sanity/pin-tang/PURPOSE
+++ b/clevis/Sanity/pin-tang/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/pin-tang
+Description: tests the tang pin functionality of clevis
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/clevis/Sanity/pin-tang/main.fmf
+++ b/clevis/Sanity/pin-tang/main.fmf
@@ -1,0 +1,32 @@
+summary: tests the tang pin functionality of clevis
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- tang
+- clevis
+- jose
+test: ./runtest.sh
+recommend:
+- clevis
+- tang
+- socat
+- expect
+- psmisc
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPpass_Security
+- Tier1
+- Tier1security
+- TierCandidatesPASS
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5, rhel-6: False
+extra-summary: /CoreOS/clevis/Sanity/pin-tang
+extra-task: /CoreOS/clevis/Sanity/pin-tang
+extra-nitrate: TC#0552030

--- a/clevis/Sanity/pin-tang/runtest.sh
+++ b/clevis/Sanity/pin-tang/runtest.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/pin-tang
+#   Description: tests the tang pin functionality of clevis
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+legacy_tang() {
+    test -x /usr/libexec/tangd-update
+}
+gen_tang_keys() {
+    rlRun "jose jwk gen -i '{\"alg\":\"ES512\"}' -o \"$1/sig.jwk\""
+    rlRun "jose jwk gen -i '{\"alg\":\"ECMR\"}' -o \"$1/exc.jwk\""
+}
+gen_tang_cache() {
+    rlRun "/usr/libexec/tangd-update \"$1\" \"$2\""
+}
+grep_b64() {
+    rlRun "jose b64 dec -i \"$2\" -O - | grep -q \"$1\"" 0 \
+        "File '$2' should contain '$1' when b64-decrypted" || \
+            jose b64 dec -i "$2" -O -
+}
+start_tang() {
+    local i= cache="$1" port="$2"
+    if [ -z "$port" ]; then
+        for i in {8000..8999}; do
+            if ! fuser -s -n tcp "$i"; then
+                port="$i"
+                break
+            fi
+        done
+    fi
+    if [ -z "$port" ] || fuser -s -n tcp "$port"; then
+        rlLogFatal "no free port found for tangd: $port" 1>&2
+        return 1
+    fi
+    nohup socat "tcp-listen:$port,fork" exec:"/usr/libexec/tangd $cache" >/dev/null &
+    local pid=$!
+    rlWaitForSocket "$port" -p "$pid"
+    rlLogInfo "started tangd $cache as pid $pid on port $port" 1>&2
+    [ ! -t 1 ] && echo "$port"
+    return 0
+}
+stop_tang() {
+    rlRun "fuser -s -k \"$1/tcp\""
+}
+
+
+PACKAGE="clevis"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "tangd setup"
+        if legacy_tang; then
+            rlRun "mkdir -p tangd/db tangd/cache"
+            gen_tang_keys "tangd/db"
+            gen_tang_cache "tangd/db" "tangd/cache"
+            port=$(start_tang "tangd/cache")
+        else
+            rlRun "mkdir -p tangd/db"
+            gen_tang_keys "tangd/db"
+            port=$(start_tang "tangd/db")
+        fi
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis encrypt, confirmed interactively"
+        echo -n "testing data string" > plain
+        expect <<CLEVIS_END
+            set timeout 60
+            spawn sh -c "clevis encrypt tang '{ \"url\": \"http://localhost:$port\" }' < plain > enc"
+            expect {
+                {*Do you wish to trust these keys} {send y\\r}
+            }
+            expect eof
+            wait
+CLEVIS_END
+        rlAssert0 "expect spawning clevis" $?
+        grep_b64 "http:" enc
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+        rm -f plain enc plain2
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis encrypt, using known thumbprint"
+        rlRun "thp=\$(jose jwk thp -i tangd/db/sig.jwk)"
+        echo -n "testing data string" > plain
+        rlRun "clevis encrypt tang '{ \"url\": \"http://localhost:$port\", \"thp\": \"$thp\" }' < plain > enc"
+        grep_b64 "http:" enc
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+        rm -f adv plain enc plain2
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis encrypt, using existing adv"
+        rlRun "wget -nv -O adv.json \"http://localhost:$port/adv\""
+        stop_tang "$port"
+        echo -n "testing data string" > plain
+        rlRun "clevis encrypt tang '{ \"url\": \"http://localhost:8123\", \"adv\": \"adv.json\" }' < plain > enc"
+        grep_b64 "http:" enc
+        if legacy_tang; then
+            start_tang "tangd/cache" 8123
+        else
+            start_tang "tangd/db" 8123
+        fi
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+        stop_tang 8123
+        if legacy_tang; then
+            port=$(start_tang "tangd/cache")
+        else
+            port=$(start_tang "tangd/db")
+        fi
+        rm -f adv plain enc plain2
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        stop_tang "$port"
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/simple-encrypt-pin-tang/Makefile
+++ b/clevis/Sanity/simple-encrypt-pin-tang/Makefile
@@ -1,0 +1,63 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+#   Description: Simple way how to test 'clevis encrypt tang'
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Martin Zeleny <mzeleny@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Simple way how to test 'clevis encrypt tang'" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis" >> $(METADATA)
+	@echo "Requires:        clevis tang wget" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/clevis/Sanity/simple-encrypt-pin-tang/PURPOSE
+++ b/clevis/Sanity/simple-encrypt-pin-tang/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+Description: Simple way how to test 'clevis encrypt tang'
+Author: Martin Zeleny <mzeleny@redhat.com>

--- a/clevis/Sanity/simple-encrypt-pin-tang/main.fmf
+++ b/clevis/Sanity/simple-encrypt-pin-tang/main.fmf
@@ -1,0 +1,26 @@
+summary: Simple way how to test 'clevis encrypt tang'
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- tang
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- SP-TBU
+- TIPfail_Security
+- Tier1
+- Tier1security
+tier: '1'
+relevancy: |
+    distro < rhel-7: False
+extra-summary: /CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+extra-task: /CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+extra-nitrate: TC#0587943

--- a/clevis/Sanity/simple-encrypt-pin-tang/runtest.sh
+++ b/clevis/Sanity/simple-encrypt-pin-tang/runtest.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/simple-encrypt-pin-tang
+#   Description: Simple way how to test 'clevis encrypt tang'
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="clevis"
+PACKAGES="${PACKAGE} tang"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+
+        rlRun "rlServiceStart tangd.socket"
+        rlRun "sleep 1"
+        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+
+        echo "testing data string" > plainFile
+    rlPhaseEnd
+
+    rlPhaseStartTest "clevis encrypt tang"
+        rlRun "test -s plainFile" 0 "File exists and has a size greater than zero"
+        rlRun "cat plainFile"
+
+        rlRun "clevis encrypt tang '{ \"url\": \"localhost\", \"adv\": \"adv.json\" }' < plainFile > encryptedFile"
+        rlRun "test -s encryptedFile" 0 "File exists and has a size greater than zero"
+        rlRun "cat encryptedFile"
+
+        rlRun "clevis decrypt < encryptedFile > decryptedFile"
+        rlRun "cat decryptedFile"
+
+        rlAssertNotDiffer plainFile decryptedFile
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rlServiceRestore tangd.socket"
+
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/clevis/Sanity/tang-high-availability/Makefile
+++ b/clevis/Sanity/tang-high-availability/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/clevis/Sanity/tang-high-availability
+#   Description: verifies sharing keys between tang servers
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/clevis/Sanity/tang-high-availability
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,15 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
-	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "Description:     verifies sharing keys between tang servers" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          clevis tang" >> $(METADATA)
+	@echo "Requires:        clevis tang jose socat expect psmisc wget" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/clevis/Sanity/tang-high-availability/PURPOSE
+++ b/clevis/Sanity/tang-high-availability/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/clevis/Sanity/tang-high-availability
+Description: verifies sharing keys between tang servers
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/clevis/Sanity/tang-high-availability/main.fmf
+++ b/clevis/Sanity/tang-high-availability/main.fmf
@@ -1,0 +1,32 @@
+summary: verifies sharing keys between tang servers
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- tang
+- clevis
+test: ./runtest.sh
+recommend:
+- clevis
+- tang
+- jose
+- socat
+- expect
+- psmisc
+- wget
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPpass_Security
+- Tier1
+- Tier1security
+- TierCandidatesPASS
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5, rhel-6: False
+extra-summary: /CoreOS/clevis/Sanity/tang-high-availability
+extra-task: /CoreOS/clevis/Sanity/tang-high-availability
+extra-nitrate: TC#0552033

--- a/clevis/Sanity/tang-high-availability/runtest.sh
+++ b/clevis/Sanity/tang-high-availability/runtest.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/clevis/Sanity/tang-high-availability
+#   Description: verifies sharing keys between tang servers
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+legacy_tang() {
+    test -x /usr/libexec/tangd-update
+}
+gen_tang_keys() {
+    rlRun "/usr/libexec/tangd-keygen \"$1\""
+}
+gen_tang_cache() {
+    rlRun "/usr/libexec/tangd-update \"$1\" \"$2\""
+}
+grep_b64() {
+    rlRun "jose b64 dec -i \"$2\" -O - | grep -q \"$1\"" 0 \
+        "File '$2' should contain '$1' when b64-decrypted" || \
+            jose b64 dec -i "$2" -O -
+}
+start_tang() {
+    local i= cache="$1" port="$2"
+    if [ -z "$port" ]; then
+        for i in {8000..8999}; do
+            if ! fuser -s -n tcp "$i"; then
+                port="$i"
+                break
+            fi
+        done
+    fi
+    if [ -z "$port" ] || fuser -s -n tcp "$port"; then
+        rlLogFatal "no free port found for tangd: $port" 1>&2
+        return 1
+    fi
+    nohup socat "tcp-listen:$port,fork" exec:"/usr/libexec/tangd $cache" >/dev/null &
+    local pid=$!
+    rlWaitForSocket "$port" -p "$pid"
+    rlLogInfo "started tangd $cache as pid $pid on port $port" 1>&2
+    [ ! -t 1 ] && echo "$port"
+    return 0
+}
+stop_tang() {
+    rlRun "fuser -s -k \"$1/tcp\""
+}
+
+
+PACKAGE="clevis"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "tangd setup"
+        if legacy_tang; then
+            rlRun "mkdir -p tangd/db tangd/cache tangd/cache2"
+            gen_tang_keys "tangd/db"
+            gen_tang_cache "tangd/db" "tangd/cache"
+            gen_tang_cache "tangd/db" "tangd/cache2"
+            port=$(start_tang "tangd/cache")
+        else
+            rlRun "mkdir -p tangd/cache tangd/cache2"
+            gen_tang_keys "tangd/cache"
+            rlRun "cp -a tangd/cache/* tangd/cache2"
+            port=$(start_tang "tangd/cache")
+        fi
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "clevis encrypt using first server, decrypt using second"
+        rlRun "wget -nv -O adv.json \"http://localhost:$port/adv\""
+        echo -n "testing data string" > plain
+        rlRun "clevis encrypt tang '{ \"url\": \"http://localhost:$port\", \"adv\": \"adv.json\" }' < plain > enc"
+        grep_b64 "http:" enc
+        stop_tang $port
+        start_tang "tangd/cache2" $port  # same port
+        rlRun "clevis decrypt < enc > plain2"
+        rlAssertNotDiffer plain plain2
+        rm -f adv plain enc plain2
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        stop_tang $port
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/Makefile
+++ b/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
+#   Description: runs jose fmt via valgrind, checking for leaks
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,16 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
+	@echo "Description:     runs jose fmt via valgrind, checking for leaks" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
 	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "RunFor:          jose" >> $(METADATA)
+	@echo "Requires:        jose valgrind" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
+	@echo "Bug:             1466278" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/PURPOSE
+++ b/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
+Description: runs jose fmt via valgrind, checking for leaks
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
+++ b/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
@@ -1,0 +1,23 @@
+summary: runs jose fmt via valgrind, checking for leaks
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- jose
+test: ./runtest.sh
+recommend:
+- jose
+- valgrind
+duration: 10m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPfail_Security
+- Tier1
+- Tier1security
+tier: '1'
+extra-summary: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
+extra-task: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
+extra-nitrate: TC#0561563

--- a/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/runtest.sh
+++ b/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt/runtest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
+#   Description: runs jose fmt via valgrind, checking for leaks
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="jose"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        # 2 separate known leaks, one in cmd_output (-o),
+        # another one in cmd_foreach (-f)
+        rlRun -s "valgrind --track-fds=yes jose fmt -j '{}' -o outputfile -f forinfile"
+        rlAssertNotGrep "Open file descriptor [0-9]*: outputfile" "$rlRun_LOG"
+        rlAssertNotGrep "Open file descriptor [0-9]*: forinfile" "$rlRun_LOG"
+        rm -f "$rlRun_LOG"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/Makefile
+++ b/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/Makefile
@@ -1,7 +1,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
+#   Makefile of /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+#   Description: runs jose jwg gen with invalid input
 #   Author: Jiri Jaburek <jjaburek@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -50,16 +50,16 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
+	@echo "Description:     runs jose jwg gen with invalid input" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          jose" >> $(METADATA)
+	@echo "Requires:        jose" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
-	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
+	@echo "Bug:             1473248" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/PURPOSE
+++ b/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+Description: runs jose jwg gen with invalid input
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
+++ b/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
@@ -1,0 +1,21 @@
+summary: runs jose jwg gen with invalid input
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- jose
+test: ./runtest.sh
+recommend:
+- jose
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- TIPfail_Security
+- Tier1
+- Tier1security
+tier: '1'
+extra-summary: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-task: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-nitrate: TC#0561564

--- a/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/runtest.sh
+++ b/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/runtest.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+#   Description: runs jose jwg gen with invalid input
+#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="jose"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+        rlRun "echo some-invalid-json > invalid.json"
+        rlRun "echo '{\"alg\":\"ES256\"}' > valid.json"
+        rlRun "echo -n > empty.json"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "jose jwk gen -i '{\"alg\":\"ES256\"}'"
+        rlRun "jose jwk gen -i valid.json"
+        rlRun "jose jwk gen -i ''" 1
+        rlRun "jose jwk gen -i empty.json" 1
+        rlRun "jose jwk gen -i invalid.json" 1
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/libcap-ng/Sanity/smoke-test/Makefile
+++ b/libcap-ng/Sanity/smoke-test/Makefile
@@ -1,12 +1,12 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Makefile of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-#   Description: runs luksmeta on a non-LUKS block device
-#   Author: Jiri Jaburek <jjaburek@redhat.com>
+#   Makefile of /CoreOS/libcap-ng/Sanity/smoke-test
+#   Description: Test calls upstream test suite.
+#   Author: Ondrej Moris <omoris@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Copyright (c) 2017 Red Hat, Inc.
+#   Copyright (c) 2010 Red Hat, Inc. All rights reserved.
 #
 #   This copyrighted material is made available to anyone wishing
 #   to use, modify, copy, or redistribute it subject to the terms
@@ -24,7 +24,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-export TEST=/CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+export TEST=/CoreOS/libcap-ng/Sanity/smoke-test
 export TESTVERSION=1.0
 
 BUILT_FILES=
@@ -37,7 +37,7 @@ run: $(FILES) build
 	./runtest.sh
 
 build: $(BUILT_FILES)
-	test -x runtest.sh || chmod a+x runtest.sh
+	chmod a+x runtest.sh
 
 clean:
 	rm -f *~ $(BUILT_FILES)
@@ -46,20 +46,27 @@ clean:
 include /usr/share/rhts/lib/rhts-make.include
 
 $(METADATA): Makefile
-	@echo "Owner:           Jiri Jaburek <jjaburek@redhat.com>" > $(METADATA)
+	@echo "Owner:           Ondrej Moris <omoris@redhat.com>" > $(METADATA)
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
-	@echo "Description:     runs luksmeta on a non-LUKS block device" >> $(METADATA)
-	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
-	@echo "RunFor:          luksmeta" >> $(METADATA)
-	@echo "Requires:        luksmeta device-mapper" >> $(METADATA)
+	@echo "Description:     Test calls upstream test suite." >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          libcap-ng" >> $(METADATA)
+	@echo "Requires:        libcap-ng" >> $(METADATA)
+	@echo "Requires:        libcap-ng-devel" >> $(METADATA)
+	@echo "Requires:        libattr-devel" >> $(METADATA)
+	@echo "Requires:        pkgconfig" >> $(METADATA)
+	@echo "Requires:        python-devel" >> $(METADATA)
+	@echo "Requires:        kernel-headers" >> $(METADATA)
+	@echo "Requires:        gcc" >> $(METADATA)
+	@echo "Requires:        swig" >> $(METADATA)
+	@echo "Requires:        python3-devel rpm-build" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1461448" >> $(METADATA)
-	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/libcap-ng/Sanity/smoke-test/PURPOSE
+++ b/libcap-ng/Sanity/smoke-test/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/libcap-ng/Sanity/smoke-test
+Description: Test calls upstream test suite.
+Author: Ondrej Moris <omoris@redhat.com>

--- a/libcap-ng/Sanity/smoke-test/main.fmf
+++ b/libcap-ng/Sanity/smoke-test/main.fmf
@@ -1,0 +1,32 @@
+summary: Test calls upstream test suite.
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component: []
+test: ./runtest.sh
+recommend:
+- libcap-ng
+- libcap-ng-devel
+- libattr-devel
+- pkgconfig
+- python-devel
+- kernel-headers
+- gcc
+- swig
+- python3-devel
+- rpm-build
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- TIPpass_Security
+- Tier1
+- Tier1security
+- rhel8-buildroot
+tier: '1'
+relevancy: |
+    distro = rhel-4, rhel-5: False
+extra-summary: '/CoreOS/libcap-ng/Sanity/smoke-test '
+extra-task: /CoreOS/libcap-ng/Sanity/smoke-test
+extra-nitrate: TC#0067930

--- a/libcap-ng/Sanity/smoke-test/runtest.sh
+++ b/libcap-ng/Sanity/smoke-test/runtest.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/libcap-ng/Sanity/smoke-test
+#   Description: Test calls upstream test suite.
+#   Author: Ondrej Moris <omoris@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2010 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include rhts environment
+. /usr/bin/rhts-environment.sh
+. /usr/share/beakerlib/beakerlib.sh
+
+PACKAGE="libcap-ng"
+
+TESTUSER="libcapngtestuser"
+
+rlJournalStart
+
+    rlPhaseStartSetup
+    
+        rlAssertRpm $PACKAGE	
+	rlRun "useradd $TESTUSER" 0-255
+	rlFetchSrcForInstalled $PACKAGE
+
+    rlPhaseEnd
+
+    rlPhaseStartTest
+    
+         rlRun "cp *.rpm /tmp/libcap.src.rpm" 0
+
+	 rlRun "/sbin/runuser -s /bin/sh -c \
+                'rpm -ihv /tmp/libcap.src.rpm' -- $TESTUSER" 0 \
+	     "Installing libcap-ng source RPM"
+	 
+         rlRun "/sbin/runuser -s /bin/sh -c \
+                'rpmbuild -vv -bc ~/rpmbuild/SPECS/libcap-ng.spec' \
+                -- $TESTUSER" 0 \
+	     "Building libcap-ng source RPM"
+
+         rlRun "/sbin/runuser -s /bin/sh -c \
+                \"make -C ~/rpmbuild/BUILD/libcap-ng* check\" \
+                >/tmp/make.check.out -- $TESTUSER" 0 \
+	     "Running libcap-ng self-test (as non-root user)"
+
+	 
+	 cat /tmp/make.check.out
+
+	if rlIsRHEL 6; then
+            rlAssertNotGrep "failed"  /tmp/make.check.out
+            rlAssertNotGrep "skipped" /tmp/make.check.out
+            rlRun "[ `grep passed /tmp/make.check.out | wc -l` -eq 2 ]" 0 "All tests should pass."
+	else
+	    rlAssertEquals "1st set of tests should pass" \
+                       `grep '# PASS:' /tmp/make.check.out | awk 'NR==1 {print $3}'` \
+                       `grep '# TOTAL:' /tmp/make.check.out | awk 'NR==1 {print $3}'`
+            if rlIsRHEL "<8"; then
+	        rlAssertEquals "2nd set of tests should pass" \
+                               `grep '# PASS:' /tmp/make.check.out | awk 'NR==2 {print $3}'` \
+                               `grep '# TOTAL:' /tmp/make.check.out | awk 'NR==2 {print $3}'`
+            fi
+	fi
+	 rm -f /tmp/make.check.out
+	 
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+
+	rlRun "userdel $TESTUSER" 0
+	rlRun "rm -rf /home/$TESTUSER" 0
+
+    rlPhaseEnd
+
+rlJournalPrintText
+
+rlJournalEnd

--- a/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/PURPOSE
+++ b/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+Description: runs luksmeta on a non-LUKS block device
+Author: Jiri Jaburek <jjaburek@redhat.com>

--- a/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/main.fmf
+++ b/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/main.fmf
@@ -1,2 +1,23 @@
-path: /luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
-tier: 1
+summary: runs luksmeta on a non-LUKS block device
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- luksmeta
+test: ./runtest.sh
+recommend:
+- luksmeta
+- device-mapper
+duration: 10m
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- NoRHEL6
+- TIPfail_Security
+- Tier1
+- Tier1security
+tier: '1'
+extra-summary: /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+extra-task: /CoreOS/luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
+extra-nitrate: TC#0561562

--- a/tang/Sanity/simple-tang-server-start/Makefile
+++ b/tang/Sanity/simple-tang-server-start/Makefile
@@ -1,0 +1,63 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/tang/Sanity/simple-tang-server-start
+#   Description: Smoke run tang server
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/tang/Sanity/simple-tang-server-start
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Martin Zeleny <mzeleny@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Run tang server, which stays running after test finishes. For manual testing with --reserve parameter." >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        24h" >> $(METADATA)
+	@echo "RunFor:          tang" >> $(METADATA)
+	@echo "Requires:        tang http-parser curl" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/tang/Sanity/simple-tang-server-start/PURPOSE
+++ b/tang/Sanity/simple-tang-server-start/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /CoreOS/tang/Sanity/simple-tang-server-start
+Description: Smoke run tang server
+Author: Martin Zeleny <mzeleny@redhat.com>

--- a/tang/Sanity/simple-tang-server-start/main.fmf
+++ b/tang/Sanity/simple-tang-server-start/main.fmf
@@ -1,0 +1,24 @@
+summary: Run tang server, which stays running after test finishes. For manual testing
+    with --reserve parameter.
+description: ''
+contact: Martin Zelený <mzeleny@redhat.com>
+component:
+- tang
+test: ./runtest.sh
+recommend:
+- tang
+- http-parser
+- curl
+duration: 24h
+enabled: true
+tag:
+- CI-Tier-1
+- NoRHEL4
+- NoRHEL5
+- Tier1
+tier: '1'
+relevancy: |
+    distro < rhel-7: False
+extra-summary: /CoreOS/tang/Sanity/simple-tang-server-start
+extra-task: /CoreOS/tang/Sanity/simple-tang-server-start
+extra-nitrate: TC#0605937

--- a/tang/Sanity/simple-tang-server-start/runtest.sh
+++ b/tang/Sanity/simple-tang-server-start/runtest.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/tang/Sanity/simple-tang-server-start
+#   Description: Smoke run tang server
+#   Author: Martin Zeleny <mzeleny@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="tang"
+PACKAGES="${PACKAGE} http-parser curl"
+TANG="tangd.socket"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm --all
+        rlRun "systemctl start ${TANG}"
+        rlRun "sleep 1"
+        rlRun "systemctl status ${TANG}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Force server to generate advertisment and get it by curl"
+        rlRun "curl -sS http://localhost/adv" 0
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "systemctl stop ${TANG}"
+        rlRun "sleep 1"
+        rlRun "systemctl status ${TANG}" 1-100
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
### Moving tests:

- clevis/Sanity/luks-edit
- clevis/Sanity/automate-clevis-luks-bind
- clevis/Sanity/luks-list
- clevis/Sanity/luks-pass
- clevis/Regression/generate-initramfs
- clevis/Sanity/simple-encrypt-pin-tang
- clevis/Sanity/bind-luks
- clevis/Sanity/tang-high-availability
- clevis/Sanity/pin-tang
- clevis/Sanity/pin-sss
- jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
- jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
- luksmeta/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error
- libcap-ng/Sanity/smoke-test
- tang/Sanity/simple-tang-server-start