### PR TITLE
rsyslog/multihost/rsyslog send messages to remote

### DIFF
--- a/rsyslog/Multihost/rsyslog-send-messages-to-remote/TC#0167027.fmf
+++ b/rsyslog/Multihost/rsyslog-send-messages-to-remote/TC#0167027.fmf
@@ -3,7 +3,6 @@ environment:
     MODES: normal
 tag:
 - Tier2
-- fedora-wanted
 tier: '2'
 extra-summary: ANSIBLE=1 MODES=normal /CoreOS/rsyslog/Multihost/rsyslog-send-messages-to-remote
 extra-nitrate: TC#0167027

--- a/rsyslog/Multihost/rsyslog-send-messages-to-remote/TC#0167028.fmf
+++ b/rsyslog/Multihost/rsyslog-send-messages-to-remote/TC#0167028.fmf
@@ -1,7 +1,6 @@
 tag:
 - TIPpass_Security
 - Tier3
-- fedora-wanted
 - notip
 - rsyslogSyntaxOLD
 tier: '3'

--- a/rsyslog/Multihost/rsyslog-send-messages-to-remote/main.fmf
+++ b/rsyslog/Multihost/rsyslog-send-messages-to-remote/main.fmf
@@ -17,6 +17,9 @@ recommend:
 - rsyslog
 - ansible
 - rhel-system-roles
+relevancy: |
+    distro < rhel-8: False
+    distro = fedora: False
 duration: 60m
 enabled: true
 extra-task: /CoreOS/rsyslog/Multihost/rsyslog-send-messages-to-remote


### PR DESCRIPTION
* Adding relevancy to fmf (disabling for Fedora)
* Removing fedora-wanted tag