### PR TITLE
fapolicyd: added test for deleted running python

### DIFF
--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
@@ -1,0 +1,68 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in
+#   Description: Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)
+#   Author: Dalibor Pospisil <dapospis@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Dalibor Pospisil <dapospis@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)" >> $(METADATA)
+	@echo "Type:            Regression" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          fapolicyd" >> $(METADATA)
+	@echo "Requires:        fapolicyd" >> $(METADATA)
+	@echo "Requires:        /usr/bin/python /usr/libexec/platform-python systemd-python3 systemd-python lsof" >> $(METADATA)
+	@echo "RhtsRequires:    library(distribution/Cleanup)" >> $(METADATA)
+	@echo "RhtsRequires:    library(fapolicyd/common)" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Bug:             1895467" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
@@ -62,7 +62,7 @@ $(METADATA): Makefile
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Bug:             1895467" >> $(METADATA)
+	@echo "Bug:             1895467 1895513 1895514 1895515" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/PURPOSE
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/PURPOSE
@@ -1,0 +1,5 @@
+PURPOSE of /CoreOS/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in
+Description: Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)
+Author: Dalibor Pospisil <dapospis@redhat.com>
+Bug summary: fapolicyd breaks system upgrade, leaving system in dead state
+Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=1895467

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/main.fmf
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/main.fmf
@@ -1,0 +1,29 @@
+summary: Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)
+description: |
+    Bug summary: fapolicyd breaks system upgrade, leaving system in dead state
+    Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=1895467
+contact: Dalibor Pospíšil <dapospis@redhat.com>
+component: []
+test: ./runtest.sh
+require:
+- library(distribution/Cleanup)
+- lsof
+- fapolicyd
+recommend:
+- library(fapolicyd/common)
+- /usr/bin/python
+- /usr/libexec/platform-python
+- systemd-python3
+- systemd-python
+duration: 5m
+enabled: true
+tag:
+- NoRHEL4
+- NoRHEL5
+- rhel-8.4.0
+- CI-Tier-1
+- FedoraCI
+relevancy: |
+    distro < rhel-8: False
+extra-nitrate: TC#0608926
+extra-summary: /CoreOS/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in
+#   Description: Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)
+#   Author: Dalibor Pospisil <dapospis@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="fapolicyd"
+
+PYTHON=`which python`
+PYTHON_SUFFIX=''
+[[ -x $PYTHON ]] || {
+  PYTHON='/usr/libexec/platform-python'
+  [[ -x $PYTHON ]] || PYTHON=`which python3`
+  PYTHON_SUFFIX='3'
+}
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+    rlRun "rlCheckRequirements $(rlGetMakefileRequires | sed -r 's|\S+/python|$PYTHON|g;s|(systemd-python)\S*|\1${PYTHON_SUFFIX}|g')" || rlDie 'cannot continue'
+    rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
+    CleanupRegister 'rlRun "popd"'
+    rlRun "pushd $TmpDir"
+    CleanupRegister 'rlRun ""fapCleanup'
+    rlRun "fapSetup"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest && {
+    PYTHON=$(readlink -e $PYTHON)
+    s=`which sleep`
+    cat > test.py <<EOF
+#!${PYTHON}
+import time
+import sys
+import os
+for i in range(1,1000):
+  print(i)
+  time.sleep(1)
+  f=open("./test.py","r")
+EOF
+    chmod a+x ./test.py
+    rlRun "./test.py &"
+    rlRun "cp $PYTHON $PYTHON.mojekopie"
+    rlRun "rm -f $PYTHON"
+    rlRun "cp $PYTHON.mojekopie $PYTHON"
+    rlRun "rm -f $PYTHON.mojekopie"
+    rlRun "lsof | grep test\.py | grep deleted"
+    rlRun "fapStart"
+    tail -f $fapolicyd_out &
+    rlRun "sleep 5"
+    kill %+
+    kill %1
+    rlRun "fapStop"
+    rlAssertGrep 'allow.*python.*:.*test\.py' $fapolicyd_out
+    rlAssertNotGrep 'deny.*python.*:.*test\.py' $fapolicyd_out
+  rlPhaseEnd; }
+
+  rlPhaseStartCleanup && {
+    CleanupDo
+  rlPhaseEnd; }
+  rlJournalPrintText
+rlJournalEnd; }


### PR DESCRIPTION
This test is covering the fapolicyd blocking system upgrade.
The running deleted binary loses its permissions as the path has
" (deleted)" suffix.