### PR TITLE
fapolicyd system install

### DIFF
--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/Makefile
@@ -52,7 +52,7 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test for BZ#1895467 (fapolicyd breaks system upgrade, leaving system in)" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "TestTime:        15m" >> $(METADATA)
 	@echo "RunFor:          fapolicyd" >> $(METADATA)
 	@echo "Requires:        fapolicyd" >> $(METADATA)
 	@echo "Requires:        /usr/bin/python /usr/libexec/platform-python systemd-python3 systemd-python lsof" >> $(METADATA)

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/main.fmf
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/main.fmf
@@ -16,7 +16,7 @@ recommend:
 - /usr/libexec/platform-python
 - systemd-python3
 - systemd-python
-duration: 5m
+duration: 15m
 enabled: true
 tag:
 - NoRHEL4

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
@@ -80,6 +80,12 @@ EOF
     rlAssertNotGrep 'deny.*python.*:.*test\.py' $fapolicyd_out
   rlPhaseEnd; }
 
+  rlPhaseStartTest "system instalability" && {
+    YUM=`which yum` || YUM=`which dnf`
+    rlRun "mkdir installroot"
+    rlRun "$YUM -y --installroot=$PWD/installroot install fapolicyd"
+  rlPhaseEnd; }
+
   rlPhaseStartCleanup && {
     CleanupDo
   rlPhaseEnd; }


### PR DESCRIPTION
added a test phase to test `yum --installroot` to mimic a fresh installation of the system