### PR TITLE
Update clevis/Sanity/bind-luks

### DIFF
--- a/clevis/Sanity/bind-luks/runtest.sh
+++ b/clevis/Sanity/bind-luks/runtest.sh
@@ -121,9 +121,8 @@ rlJournalStart
             expect {
                 {*Do you wish to trust these keys} {send y\\r; exp_continue}
                 {*Do you wish to initialize} {send y\\r; exp_continue}
-                {*Enter existing LUKS password} {send redhat123\\r}
+                {*Enter existing LUKS password} {send redhat123\\r; exp_continue}
             }
-            expect eof
             exit [lindex [wait] 3]
 CLEVIS_END
         rlAssert0 "expect spawning clevis" $?


### PR DESCRIPTION
Current upstream clevis had a slight change in clevis luks bind and now
the passphrase is asked first, so let's adapt the test to be able to
handle it as well.