### PR TITLE
libfastjson/Sanity/bz1936807-API-function-calls initial commit

### DIFF
--- a/libfastjson/Sanity/bz1936807-API-function-calls/Makefile
+++ b/libfastjson/Sanity/bz1936807-API-function-calls/Makefile
@@ -1,0 +1,15 @@
+TARGET=main
+CC=gcc
+LIBFASTJSON_FLAGS=$(shell pkg-config --cflags libfastjson)
+LIBFASTJSON_LIBS=$(shell pkg-config --libs libfastjson)
+
+all: $(TARGET)
+
+$(TARGET): $(TARGET).c
+	$(CC) $(LIBFASTJSON_FLAGS) -o $(TARGET) $(TARGET).c $(LIBFASTJSON_LIBS)
+
+test:
+	./$(TARGET)
+
+clean:
+	rm -rf $(TARGET)

--- a/libfastjson/Sanity/bz1936807-API-function-calls/main.c
+++ b/libfastjson/Sanity/bz1936807-API-function-calls/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdio.h>
+#include <json.h>
+
+int main() {
+
+    fjson_object *json_array = fjson_object_new_array();
+    assert(fjson_object_array_length(json_array) == 0);
+    const int size = 10;
+
+    for (int i = 0; i < size; i++) {
+        fjson_object *json_item = fjson_object_new_int(i);
+        fjson_object_array_put_idx(json_array, i, json_item);
+    }
+    assert(fjson_object_array_length(json_array) == size);
+
+    for (int i = size-1; i >= 0; i--) {
+        fjson_object_array_del_idx(json_array, i);
+    }
+    assert(fjson_object_array_length(json_array) == 0);
+
+    return EXIT_SUCCESS;
+}

--- a/libfastjson/Sanity/bz1936807-API-function-calls/main.fmf
+++ b/libfastjson/Sanity/bz1936807-API-function-calls/main.fmf
@@ -2,6 +2,10 @@ summary: added new API call fjson_object_array_del_idx()
 contact:
 - Atilla Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
+require+:
+- libfastjson-devel
+- gcc
+- make
 duration: 5m
 tag:
 - CI-Tier-1

--- a/libfastjson/Sanity/bz1936807-API-function-calls/main.fmf
+++ b/libfastjson/Sanity/bz1936807-API-function-calls/main.fmf
@@ -1,0 +1,11 @@
+summary: added new API call fjson_object_array_del_idx()
+contact:
+- Atilla Lakatos <alakatos@redhat.com>
+test: ./runtest.sh
+duration: 5m
+tag:
+- CI-Tier-1
+- Tier2
+tier: 2
+extra-nitrate: TC#0610373
+extra-task: /libfastjson/Sanity/bz1936807-API-function-calls

--- a/libfastjson/Sanity/bz1936807-API-function-calls/runtest.sh
+++ b/libfastjson/Sanity/bz1936807-API-function-calls/runtest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/tests-libfastjson/Sanity/bz1936807-API-function-calls
+#   Description: Check the presence of recently added API functions, such as fjson_object_array_del_idx
+#   Author: Attila Lakatos <alakatos@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2021 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="tests-libfastjson"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "rlImport --all" || rlDie 'cannot continue'
+    rlPhaseEnd
+
+    rlPhaseStartTest '' && {
+        rlRun "make" 0 "Compile source files. If fjson_object_array_del_idx() function is not present, this will fail."
+        rlRun "make test" 0 "Execute simple unit test."
+    rlPhaseEnd; }
+
+    rlPhaseStartCleanup
+        rlRun "make clean" 0 "Clean up working directory."
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/libfastjson/main.fmf
+++ b/libfastjson/main.fmf
@@ -1,0 +1,6 @@
+component: libfastjson
+require:
+- libfastjson
+- libfastjson-devel
+- gcc
+- make

--- a/libfastjson/main.fmf
+++ b/libfastjson/main.fmf
@@ -1,6 +1,3 @@
 component: libfastjson
 require:
 - libfastjson
-- libfastjson-devel
-- gcc
-- make


### PR DESCRIPTION
This is still in progress. Checklist:

- [X] Create test for recently added API functions, such as ```json_object_array_del_idx```.
- [x] Add main.fmf file. The test requires ```libfastjson-devel``` and ```make```.