### PR TITLE
libcap-ng/Regression/compare-capabilities-from-captest-and-capsh

### DIFF
--- a/libcap-ng/Regression/compare-capabilities-from-captest-and-capsh/runtest.sh
+++ b/libcap-ng/Regression/compare-capabilities-from-captest-and-capsh/runtest.sh
@@ -34,25 +34,38 @@ PACKAGE="libcap-ng"
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm $PACKAGE
-	      rlRun "uname -a"
+        rlRun "uname -a"
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
-	      rlRun -s "captest --text"
+        rlRun -s "captest --text"
         mv $rlRun_LOG captest.out
-	      rlRun -s "captest"
+        rlRun -s "captest"
         mv $rlRun_LOG  hexadec.out
-	      HEXA=`awk '/^Effective:/ { print $2,$3; exit }' hexadec.out | sed 's/, //'`
-	      rlLogInfo "hexadecimal representation of Effective capabilities: $HEXA"
-	      rlRun -s "capsh --decode=$HEXA"
-	      mv $rlRun_LOG capsh.out
-	      # now convert output to a better form
-	      rlRun "cut -d '=' -f 2 capsh.out | sed -e 's/cap_//g' -e 's/,/\\n/g' | sort > capsh_sorted.out"
-	      rlRun "sed -e 's/35/wake_alarm/' -e 's/36/block_suspend/' -e 's/37/audit_read/' -e 's/38/cap_38/' -e 's/39/cap_39/' capsh_sorted.out | sort > capsh_sorted2.out" 0 "substituting unknown/numeric capabilities in the output"
-	      rlRun "grep '^Effective' captest.out | sed -e 's/Effective: //' -e 's/, /\\n/g' | sort > captest_sorted.out"
+        HEXA=`awk '/^Effective:/ { print $2,$3; exit }' hexadec.out | sed 's/, //'`
+        rlLogInfo "hexadecimal representation of Effective capabilities: $HEXA"
+        rlRun -s "capsh --decode=$HEXA"
+        mv $rlRun_LOG capsh.out
+        # now convert output to a better form
+
+        rlRun "cut -d '=' -f 2 capsh.out \
+            | sed -e 's/cap_//g' \
+                -e 's/,/\\n/g' \
+                -e 's/35/wake_alarm/' \
+                -e 's/36/block_suspend/' \
+                -e 's/37/audit_read/' \
+            | sed -e '/^[0-9]\+$/d' \
+            | sort > capsh_sorted.out" 0 "substituting unknown/numeric capabilities in the output"
+
+        rlRun "grep '^Effective' captest.out | sed -e 's/Effective: //' -e 's/, /\\n/g' | sort > captest_sorted.out"
     rlPhaseEnd
 
-    rlPhaseStartTest
-	      rlRun "diff capsh_sorted2.out captest_sorted.out" 0 "'Effective permissions listed by captest --text' and 'capsh --decode=$HEXA' should match"
+    rlPhaseStartTest "Effective permissions listed by 'capsh --decode=$HEXA' are available in 'captest --text'"
+        rlRun "cat capsh_sorted.out"
+        rlRun "cat captest_sorted.out"
+
+        for cap in $(cat capsh_sorted.out); do
+            rlAssertGrep "${cap}" captest_sorted.out
+        done
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
List of capabilities that are known to 'capsh' and 'captest' are not
identical. New capabilities in 'captest' are not to be known by 'capsh'.
Unknown numerical capabilities from 'capsh' output are removed, becase
they may be named differently in 'captest'.