### PR TITLE
rsyslog/Sanity/imrelp-omrelp-module-test: Enforcing system crypto policies

### DIFF
--- a/rsyslog/Sanity/imrelp-omrelp-module-test/main.fmf
+++ b/rsyslog/Sanity/imrelp-omrelp-module-test/main.fmf
@@ -12,6 +12,7 @@ recommend:
 - rsyslog-gnutls
 - openssl
 - librelp
+- rpmlint
 duration: 15m
 enabled: true
 tag:

--- a/rsyslog/Sanity/imrelp-omrelp-module-test/runtest.sh
+++ b/rsyslog/Sanity/imrelp-omrelp-module-test/runtest.sh
@@ -169,6 +169,12 @@ EOF
 
     tcfTry "Tests" --no-assert && {
 
+        rlPhaseStartTest "Ensure system crypto policies are used by default"
+            rlRun -s "rpmlint --info librelp" 0-64 "Check for common rpm problems"
+            rlAssertNotGrep "crypto-policy-non-compliance-gnutls" $rlRun_LOG
+            rlAssertNotGrep "crypto-policy-non-compliance-openssl" $rlRun_LOG
+        rlPhaseEnd;
+
         for client_driver in "gnutls" "openssl"; do
             for server_driver in "gnutls" "openssl"; do
                 rlPhaseStartTest "$client_driver -> $server_driver" && tcfChk && {


### PR DESCRIPTION
Ensure that system-wide crypto policies are used. Both _gnutls_ and _openssl_ are covered.