### PR TITLE
Update fapolicyd/Sanity/cli-options AC4 criteria

### DIFF
--- a/fapolicyd/Sanity/cli-options/runtest.sh
+++ b/fapolicyd/Sanity/cli-options/runtest.sh
@@ -112,7 +112,7 @@ rlJournalStart && {
 
     rlPhaseStartTest "file subcommands AC4" && {
       rlRun -s "fapolicyd-cli -f blabla" 1-255
-      rlAssertGrep "missing operation option|invalid|unknown|illegal|bad|unrecognized|undefined|unexpected" $rlRun_LOG -Eiq
+      rlAssertGrep "not a valid option|missing operation option|invalid|unknown|illegal|bad|unrecognized|undefined|unexpected" $rlRun_LOG -Eiq
       rm -f $rlRun_LOG
     rlPhaseEnd; }
 


### PR DESCRIPTION
"not a valid option" substring will match current upstream error output