### PR TITLE
fapolicyd service debug

### DIFF
--- a/fapolicyd/Regression/abnormal-exit/runtest.sh
+++ b/fapolicyd/Regression/abnormal-exit/runtest.sh
@@ -54,11 +54,13 @@ rlJournalStart
     rlRun "cat $testfile"
     rlRun "fapStop"
     rlRun "rm -f $testfile"
-    rlRun "cat $fapolicyd_out"
-    rlAssertGrep 'RETURN CODE: 0' $fapolicyd_out
-    rlAssertGrep 'Starting to listen for events' $fapolicyd_out
-    rlAssertNotGrep 'Error receiving fanotify_event (Permission denied)' $fapolicyd_out
-    rlAssertNotGrep 'Error reading (Permission denied)' $fapolicyd_out
+    rlRun -s "fapServiceOut -t"
+    rlAssertGrep 'shutting down' $rlRun_LOG
+    rlAssertGrep 'succeeded' $rlRun_LOG -iq
+    rlAssertGrep 'Starting to listen for events' $rlRun_LOG
+    rlAssertNotGrep 'Error receiving fanotify_event (Permission denied)' $rlRun_LOG
+    rlAssertNotGrep 'Error reading (Permission denied)' $rlRun_LOG
+    rm -f $rlRun_LOG
   rlPhaseEnd
 
   rlPhaseStartTest "blocked by permissions"
@@ -68,11 +70,13 @@ rlJournalStart
     rlRun "cat $testfile"
     rlRun "fapStop"
     rlRun "rm -f $testfile"
-    rlRun "cat $fapolicyd_out"
-    rlAssertGrep 'RETURN CODE: 0' $fapolicyd_out
-    rlAssertGrep 'Starting to listen for events' $fapolicyd_out
-    rlAssertNotGrep 'Error receiving fanotify_event (Permission denied)' $fapolicyd_out
-    rlAssertNotGrep 'Error reading (Permission denied)' $fapolicyd_out
+    rlRun -s "fapServiceOut -t"
+    rlAssertGrep 'shutting down' $rlRun_LOG
+    rlAssertGrep 'succeeded' $rlRun_LOG -iq
+    rlAssertGrep 'Starting to listen for events' $rlRun_LOG
+    rlAssertNotGrep 'Error receiving fanotify_event (Permission denied)' $rlRun_LOG
+    rlAssertNotGrep 'Error reading (Permission denied)' $rlRun_LOG
+    rm -f $rlRun_LOG
   rlPhaseEnd
 
   rlPhaseStartTest "blocked by selinux - modify fapolicyd module"
@@ -88,11 +92,13 @@ rlJournalStart
     rlRun "cat $testfile" 1-255
     rlRun "fapStop"
     rlRun "rm -f $testfile"
-    rlRun "cat $fapolicyd_out"
-    rlAssertGrep 'RETURN CODE: 0' $fapolicyd_out
-    rlAssertGrep 'Starting to listen for events' $fapolicyd_out
-    rlAssertGrep 'Error receiving fanotify_event (Permission denied)' $fapolicyd_out
-    rlAssertNotGrep 'Error reading (Permission denied)' $fapolicyd_out
+    rlRun -s "fapServiceOut -t"
+    rlAssertGrep 'shutting down' $rlRun_LOG
+    rlAssertGrep 'succeeded' $rlRun_LOG -iq
+    rlAssertGrep 'Starting to listen for events' $rlRun_LOG
+    rlAssertGrep 'Error receiving fanotify_event (Permission denied)' $rlRun_LOG
+    rlAssertNotGrep 'Error reading (Permission denied)' $rlRun_LOG
+    rm -f $rlRun_LOG
     rlRun "rlSEAVCCheck --expect sysctl_vm_t selinux"
     CleanupDo --mark
   rlPhaseEnd
@@ -125,11 +131,13 @@ EOF
     rlRun "cat $testfile" 1-255
     rlRun "fapStop"
     rlRun "rm -f $testfile"
-    rlRun "cat $fapolicyd_out"
-    rlAssertGrep 'RETURN CODE: 0' $fapolicyd_out
-    rlAssertGrep 'Starting to listen for events' $fapolicyd_out
-    rlAssertGrep 'Error receiving fanotify_event (Permission denied)' $fapolicyd_out
-    rlAssertNotGrep 'Error reading (Permission denied)' $fapolicyd_out
+    rlRun -s "fapServiceOut -t"
+    rlAssertGrep 'shutting down' $rlRun_LOG
+    rlAssertGrep 'succeeded' $rlRun_LOG -iq
+    rlAssertGrep 'Starting to listen for events' $rlRun_LOG
+    rlAssertGrep 'Error receiving fanotify_event (Permission denied)' $rlRun_LOG
+    rlAssertNotGrep 'Error reading (Permission denied)' $rlRun_LOG
+    rm -f $rlRun_LOG
     rlRun "rlSEAVCCheck --expect mujtyp_file_t selinux"
     CleanupDo --mark
   rlPhaseEnd

--- a/fapolicyd/Regression/bz1757736-fapolicyd-blocks-dracut-from-generating-initramfs/runtest.sh
+++ b/fapolicyd/Regression/bz1757736-fapolicyd-blocks-dracut-from-generating-initramfs/runtest.sh
@@ -75,8 +75,9 @@ rlJournalStart
     rlPhaseStartTest "running dynamic interpreter as a root with fapolicyd"
         rlRun "fapStart" >/dev/null
         rlRun "$DYNAMIC_INTERPRETER $LS"
-        rlRun "fapStop -k"
-        rlFileSubmit $fapolicyd_out fapolicyd.out1
+        rlRun "fapStop"
+        fapServiceOut > fapolicyd_out
+        rlFileSubmit fapolicyd_out fapolicyd.out1
     rlPhaseEnd
 
     rlPhaseStartTest "running dracut without fapolicyd"
@@ -86,8 +87,9 @@ rlJournalStart
     rlPhaseStartTest "running dracut with fapolicyd"
         rlRun "fapStart" >/dev/null
         rlRun "dracut -f --regenerate-all"
-        rlRun "fapStop -k"
-        rlFileSubmit $fapolicyd_out fapolicyd.out2
+        rlRun "fapStop"
+        fapServiceOut > fapolicyd_out
+        rlFileSubmit fapolicyd_out fapolicyd.out2
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/fapolicyd/Regression/bz1765039-fapolicyd-fails-to-identify-perl-interpreter/runtest.sh
+++ b/fapolicyd/Regression/bz1765039-fapolicyd-fails-to-identify-perl-interpreter/runtest.sh
@@ -67,10 +67,10 @@ rlJournalStart
     	rlRun "fapStart"
 	rlRun "sudo -n -u $USER $INTERPRETER $SCRIPT_PATH" 1-255
 	rlRun "sleep 3"
-	rlRun "fapStop -k"
-	rlRun "cat $fapolicyd_out"
-	rlAssertGrep ".*dec=deny_audit.*exe=$INTERPRETER.*:.*(file|path)=$SCRIPT_PATH.*ftype=text/x-perl.*" $fapolicyd_out -Eq
-	rm -f $fapolicyd_out
+	rlRun "fapStop"
+	rlRun -s "fapServiceOut"
+	rlAssertGrep ".*dec=deny_audit.*exe=$INTERPRETER.*:.*(file|path)=$SCRIPT_PATH.*ftype=text/x-perl.*" $rlRun_LOG -Eq
+	rm -f $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/fapolicyd/Regression/bz1817413-segfault-on-update/runtest.sh
+++ b/fapolicyd/Regression/bz1817413-segfault-on-update/runtest.sh
@@ -47,7 +47,7 @@ rlJournalStart && {
   test() {
     rlLog "trying scenario $1 ::::::::"
     rlRun "fapStart"
-    tail -f $fapolicyd_out &
+    fapServiceOut -b -t -f
     CleanupRegister --mark "disown $!; kill $!"
     rlRun "$1" 0-255
     i=120
@@ -56,7 +56,12 @@ rlJournalStart && {
       sleep 1s
       echo -n .
     done
-    rlAssertGrep 'RETURN CODE: 0$' $fapolicyd_out
+    fapServiceOut > fapolicyd_out
+    rlAssertGrep 'shutting down' fapolicyd_out
+    rlAssertGrep 'succeeded' fapolicyd_out -iq
+    rlRun -s "rlServiceStatus fapolicyd" 1-255
+    rlAssertNotGrep 'SEGV' $rlRun_LOG
+    rm -f $rlRun_LOG
     CleanupDo --mark
   }
 

--- a/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
+++ b/fapolicyd/Regression/bz1895467-fapolicyd-breaks-system-upgrade-leaving-system-in/runtest.sh
@@ -73,13 +73,14 @@ EOF
     rlRun "rm -f $PYTHON.mojekopie"
     rlRun "lsof | grep test\.py | grep deleted"
     rlRun "fapStart --debug"
-    tail -f $fapolicyd_out &
+    fapServiceOut -b -f
     rlRun "sleep 5"
     kill %+
     kill %1
     rlRun "fapStop"
-    rlAssertGrep 'allow.*python.*:.*test\.py' $fapolicyd_out
-    rlAssertNotGrep 'deny.*python.*:.*test\.py' $fapolicyd_out
+    fapServiceOut > fapolicyd_out
+    rlAssertGrep 'allow.*python.*:.*test\.py' fapolicyd_out
+    rlAssertNotGrep 'deny.*python.*:.*test\.py' fapolicyd_out
   rlPhaseEnd; }
 
   rlPhaseStartTest "system instalability" && {

--- a/fapolicyd/Sanity/gid-selector/runtest.sh
+++ b/fapolicyd/Sanity/gid-selector/runtest.sh
@@ -65,7 +65,7 @@ rlJournalStart && {
       rlRun "su - $testUser -c 'id'"
       rlRun "su - $testUser -c '$test_dir/ls'"
       CleanupDo --mark
-      rlRun "cat $fapolicyd_out"
+      rlRun "fapServiceOut -t"
     rlPhaseEnd; }
 
 
@@ -82,7 +82,7 @@ rlJournalStart && {
       rlRun "su - $testUser -c 'id'"
       rlRun "su - $testUser -c '$test_dir/ls'" 126
       CleanupDo --mark
-      rlRun "cat $fapolicyd_out"
+      rlRun "fapServiceOut -t"
     rlPhaseEnd; }
 
 
@@ -100,7 +100,7 @@ rlJournalStart && {
       rlRun "su - $testUser -c 'id'"
       rlRun "su - $testUser -c '$test_dir/ls'" 126
       CleanupDo --mark
-      rlRun "cat $fapolicyd_out"
+      rlRun "fapServiceOut -t"
     rlPhaseEnd; }
   tcfFin; }
 

--- a/fapolicyd/Sanity/integrity/runtest.sh
+++ b/fapolicyd/Sanity/integrity/runtest.sh
@@ -75,7 +75,7 @@ rlJournalStart && {
     rlRun "fapStart --debug"
     uRun "$TmpDir/ls" 126
     CleanupDo --mark
-    rlRun "cat $fapolicyd_out"
+    rlRun "fapServiceOut -t"
   rlPhaseEnd; }
 
   rlPhaseStartTest "integrity none" && {
@@ -104,7 +104,7 @@ rlJournalStart && {
     rlRun "cat /bin/ls > $fapTestProgram"
     uRun "$fapTestProgram" 126
     CleanupDo --mark
-    rlRun "cat $fapolicyd_out"
+    rlRun "fapServiceOut -t"
   rlPhaseEnd; }
 
   rlPhaseStartTest "integrity sha256" && {
@@ -119,7 +119,7 @@ rlJournalStart && {
     rlRun "cat /bin/ls > $fapTestProgram"
     uRun "$fapTestProgram" 126
     CleanupDo --mark
-    rlRun "cat $fapolicyd_out"
+    rlRun "fapServiceOut -t"
   rlPhaseEnd; }
 
   rlPhaseStartCleanup && {

--- a/fapolicyd/Sanity/ipa-integration/runtest.sh
+++ b/fapolicyd/Sanity/ipa-integration/runtest.sh
@@ -64,7 +64,7 @@ rlJournalStart && {
       rlRun "fapSetup"
       CleanupRegister 'rlRun "fapStop"'
       rlRun "fapStart" > /dev/null
-      tail -f $fapolicyd_out &
+      fapServiceOut -b -f
       CleanupRegister "kill $!"
       h=( $(hostname -A) )
       IPA_MACHINE_HOSTNAME=`hostname`

--- a/fapolicyd/Sanity/sets/runtest.sh
+++ b/fapolicyd/Sanity/sets/runtest.sh
@@ -210,7 +210,7 @@ EOF
         rlRun "./$exe3" 126
         rlRun "./$exe4" 126
         rlRun "fapStop"
-        rlRun "cat $fapolicyd_out"
+        rlRun "fapServiceOut -t"
       tcfFin; }
       $spaces && tcfChk "space ( )" && {
         cat > /etc/fapolicyd/fapolicyd.rules <<EOF
@@ -226,7 +226,7 @@ EOF
         rlRun "./$exe3" 126
         rlRun "./$exe4" 126
         rlRun "fapStop"
-        rlRun "cat $fapolicyd_out"
+        rlRun "fapServiceOut -t"
       tcfFin; }
     rlPhaseEnd; }
 
@@ -246,7 +246,7 @@ EOF
         rlRun "./$exe3" 126
         rlRun "./$exe4" 126
         rlRun "fapStop"
-        rlRun "cat $fapolicyd_out"
+        rlRun "fapServiceOut -t"
       tcfFin; }
     rlPhaseEnd; }
 
@@ -263,7 +263,8 @@ EOF
         #rlRun "./$exe3" 126
         #rlRun "./$exe4" 126
         rlRun "fapStop"
-        rlAssertGrep "set 'mylist'.*not defined before" $fapolicyd_out -Eiq
+        fapServiceOut > fapolicyd_out
+        rlAssertGrep "set 'mylist'.*not defined before" fapolicyd_out -Eiq
     rlPhaseEnd; }
 
     rlPhaseStartTest "invalid rule AC20" && {

--- a/fapolicyd/Sanity/trust-db/runtest.sh
+++ b/fapolicyd/Sanity/trust-db/runtest.sh
@@ -139,7 +139,8 @@ rlJournalStart && {
       Trust 'file;rpmdb'
       CleanupRegister --mark 'rlRun "Stop"'
       rlRun "Start" 0-255
-      rlAssertGrep 'file;rpmdb backend not supported, aborting' $fapolicyd_out
+      fapServiceOut > fapolicyd_out
+      rlAssertGrep 'file;rpmdb backend not supported, aborting' fapolicyd_out
       CleanupDo --mark
     rlPhaseEnd; }
 
@@ -147,7 +148,8 @@ rlJournalStart && {
       Trust 'blabla'
       CleanupRegister --mark 'rlRun "Stop"'
       rlRun "Start" 0-255
-      rlAssertGrep 'blabla backend not supported, aborting' $fapolicyd_out
+      fapServiceOut > fapolicyd_out
+      rlAssertGrep 'blabla backend not supported, aborting' fapolicyd_out
       CleanupDo --mark
     rlPhaseEnd; }
 


### PR DESCRIPTION
The library used its own way of running fapolicyd in debug and debug-deny mode. This is necessary to the future changed to the way of rules processing.