### PR TITLE
fapolicyd/Sanity/trusted-execution: converted to be compatible with upgrade testing

### DIFF
--- a/fapolicyd/Sanity/trusted-execution/Makefile
+++ b/fapolicyd/Sanity/trusted-execution/Makefile
@@ -1,0 +1,66 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/fapolicyd/Sanity/cli-options
+#   Description: Test for BZ#1817413 (Rebase FAPOLICYD to the latest upstream version)
+#   Author: Dalibor Pospisil <dapospis@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/fapolicyd/Sanity/trusted-execution
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Dalibor Pospisil <dapospis@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     test execution of trusted objects" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          fapolicyd" >> $(METADATA)
+	@echo "Requires:        fapolicyd gcc" >> $(METADATA)
+	@echo "RhtsRequires:    library(distribution/Cleaup)" >> $(METADATA)
+	@echo "RhtsRequires:    library(distribution/testUser)" >> $(METADATA)
+	@echo "RhtsRequires:    library(fapolicyd/common)" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/fapolicyd/Sanity/trusted-execution/main.fmf
+++ b/fapolicyd/Sanity/trusted-execution/main.fmf
@@ -16,3 +16,4 @@ adjust:
     continue: false
 extra-nitrate: TC#0612715
 extra-summary: tests/fapolicyd/Sanity/trusted-execution - test execution of trusted objects
+extra-task: /CoreOS/fapolicyd/Sanity/trusted-execution

--- a/fapolicyd/Sanity/trusted-execution/main.fmf
+++ b/fapolicyd/Sanity/trusted-execution/main.fmf
@@ -1,4 +1,4 @@
-summary: test execution of trusted objects
+description: test execution of trusted objects
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:


### PR DESCRIPTION
This change introduces a compatibility with upgrade testing which means that just specific parts of the test are executed before the system upgrade and other parts after it.

Mainly the setup part is executed only before the upgrade and the cleanup is not executed at all.

This is controlled by the IN_PLACE_UPGRADE environment variable. If not set, the test runs the same as before (regular testing with all the phases executed).