### PR TITLE
test for rules.d

### DIFF
--- a/fapolicyd/Functional/SoftwareRestrictionPoliciesTest12/runtest.sh
+++ b/fapolicyd/Functional/SoftwareRestrictionPoliciesTest12/runtest.sh
@@ -55,7 +55,7 @@ int main(int argc, char * argv[]){
 EOF
     rlRun "gcc main.c -o my-ls"
         rlRun "chown -R xxx:xxx ."
-    rlRun "cat /etc/fapolicyd/fapolicyd.rules"
+    rlRun "cat /etc/fapolicyd/fapolicyd.rules || cat /etc/fapolicyd/compiled.rules"
     rlPhaseEnd
 
     rlPhaseStartTest

--- a/fapolicyd/Functional/SoftwareRestrictionPoliciesTest7/runtest.sh
+++ b/fapolicyd/Functional/SoftwareRestrictionPoliciesTest7/runtest.sh
@@ -38,6 +38,10 @@ rlJournalStart
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
         rlRun "fapSetup"
+        [[ -e /etc/fapolicyd/rules.d ]] && {
+          rlRun "mv /etc/fapolicyd/compiled.rules /etc/fapolicyd/fapolicyd.rules"
+          rlRun "rm -f /etc/fapolicyd/rules.d/*"
+        }
 	rlRun "mkdir testing"
 	rlRun 'echo -e "#!/bin/bash\nid\n" > testing/myscript'
 	rlRun "chmod a+x testing/myscript"

--- a/fapolicyd/Sanity/FapolicydRules/runtest.sh
+++ b/fapolicyd/Sanity/FapolicydRules/runtest.sh
@@ -38,6 +38,10 @@ rlJournalStart
         rlRun 'TmpDir=$(mktemp -d)' 0 'Creating tmp directory'
         rlRun "pushd $TmpDir"
         rlRun "fapSetup"
+        [[ -e /etc/fapolicyd/rules.d ]] && {
+          rlRun "mv /etc/fapolicyd/compiled.rules /etc/fapolicyd/fapolicyd.rules"
+          rlRun "rm -f /etc/fapolicyd/rules.d/*"
+        }
         echo 'int main(void) { return 0; }' > main.c
         exe1="exe1"
         exe2="exe2"

--- a/fapolicyd/Sanity/cli-options/runtest.sh
+++ b/fapolicyd/Sanity/cli-options/runtest.sh
@@ -195,7 +195,9 @@ rlJournalStart && {
     rlPhaseStartTest "rules listing AC10" && {
       rlRun -s "fapolicyd-cli -l 2> /dev/null"
       a=$rlRun_LOG
-      rlRun -s "grep -Ev '^(#|\s*\$)' /etc/fapolicyd/fapolicyd.rules | grep -E '^(allow|deny|%)' | sed -r 's/^%/-> \0/' | awk 'BEGIN {i=1} /^(allow|deny)/{print i++ \". \" \$0} /^-> %/{print}'"
+      rule_file="/etc/fapolicyd/fapolicyd.rules"
+      [[ -e /etc/fapolicyd/compiled.rules ]] && rule_file="/etc/fapolicyd/compiled.rules"
+      rlRun -s "grep -Ev '^(#|\s*\$)' $rule_file | grep -E '^(allow|deny|%)' | sed -r 's/^%/-> \0/' | awk 'BEGIN {i=1} /^(allow|deny)/{print i++ \". \" \$0} /^-> %/{print}'"
       b=$rlRun_LOG
       rlRun "diff -u $a $b"
       rm -f $a $b

--- a/fapolicyd/Sanity/gid-selector/runtest.sh
+++ b/fapolicyd/Sanity/gid-selector/runtest.sh
@@ -47,6 +47,10 @@ rlJournalStart && {
     rlRun "chmod -R a+rx $test_dir"
     CleanupRegister 'rlRun "fapCleanup"'
     rlRun "fapSetup"
+    [[ -e /etc/fapolicyd/rules.d ]] && {
+      rlRun "mv /etc/fapolicyd/compiled.rules /etc/fapolicyd/fapolicyd.rules"
+      rlRun "rm -f /etc/fapolicyd/rules.d/*"
+    }
     rlRun "sed -r -i '/^syslog_format = /d' /etc/fapolicyd/fapolicyd.conf"
     rlRun "echo 'syslog_format = rule,dec,perm,auid,pid,gid,exe,:,path,ftype' >> /etc/fapolicyd/fapolicyd.conf"
   rlPhaseEnd; }

--- a/fapolicyd/Sanity/rules-d/main.fmf
+++ b/fapolicyd/Sanity/rules-d/main.fmf
@@ -1,0 +1,23 @@
+description: Test for rules.d directory
+contact: Dalibor Pospíšil <dapospis@redhat.com>
+test: ./runtest.sh
+duration: 15m
+enabled: true
+require+:
+  - library(distribution/tcf)
+  - library(ControlFlow/Cleanup)
+  - library(rpm/snapshot)
+  - /usr/bin/rpmbuild
+  - /usr/bin/createrepo
+  - /usr/bin/yum-builddep
+tag:
+  - CI-Tier-1
+  - Tier1
+  - rhel-8.6.0
+  - rhel-9.0.0
+tier: '1'
+adjust:
+  - enabled: false
+    when: distro < rhel-8.6
+    continue: false
+extra-nitrate: TC#0612915

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -38,6 +38,8 @@ rlJournalStart && {
     CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
     CleanupRegister 'rlRun "popd"'
     rlRun "pushd $TmpDir"
+    CleanupRegister 'rlRun "rlFileRestore"'
+    rlRun "rlFileBackup --clean /root/rpmbuild"
     CleanupRegister --mark "rlRun 'RpmSnapshotRevert'; rlRun 'RpmSnapshotDiscard'"
     rlRun "RpmSnapshotCreate"
     CleanupRegister 'rlRun "fapCleanup"'

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -154,8 +154,8 @@ EOF
       rlRun "yum install fapolicyd-$V-$R -y --allowerasing"
       rlRun "ls -la /etc/fapolicyd/"
       rlRun "ls -la /etc/fapolicyd/rules.d/"
-      rlAssertNotExists /etc/fapolicyd/fapolicyd.rules
-      rlAssertGreater "rules are deployed into /etc/fapolicyd/rules.d" $(ls -1 /etc/fapolicyd/rules.d | wc -w) 0
+      rlAssertExists /etc/fapolicyd/fapolicyd.rules
+      rlAssertEquals "rules are deployed into /etc/fapolicyd/rules.d" $(ls -1 /etc/fapolicyd/rules.d | wc -w) 0
     rlPhaseEnd; }
 
     rlPhaseStartTest "upgrade from old version - changed rules" && {
@@ -183,7 +183,8 @@ EOF
       rlRun "ls -la /etc/fapolicyd/"
       rlRun "ls -la /etc/fapolicyd/rules.d/"
       rlRun -s "cat /etc/fapolicyd/rules.d/95-allow-open.rules"
-      rlAssertGrep 'allow perm=any' $rlRun_LOG
+      rlAssertGrep 'allow perm=open' $rlRun_LOG
+      rlAssertNotGrep 'allow perm=any' $rlRun_LOG
     rlPhaseEnd; }
 
     rlPhaseStartTest "upgrade to new version - custom rules file added" && {
@@ -218,7 +219,8 @@ EOF
       rlRun "ls -la /etc/fapolicyd/"
       rlRun "ls -la /etc/fapolicyd/rules.d/"
       rlRun -s "cat /etc/fapolicyd/rules.d/95-allow-open.rules"
-      rlAssertGrep 'allow perm=any' $rlRun_LOG
+      rlAssertGrep 'allow perm=open' $rlRun_LOG
+      rlAssertNotGrep 'allow perm=any' $rlRun_LOG
       rlAssertGrep 'allow perm=open exe=/path/to/binary : all' /etc/fapolicyd/rules.d/51-custom.rules
     rlPhaseEnd; }
 

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -95,6 +95,16 @@ EOF
   rlPhaseEnd; }
 
   tcfTry "Tests" --no-assert && {
+    rlPhaseStartTest "clean install" && {
+      rlRun "rm -rf /etc/fapolicyd"
+      rlRun "yum remove fapolicyd -y"
+      rlRun "yum install fapolicyd-$V-$R -y --allowerasing"
+      rlRun "ls -la /etc/fapolicyd/"
+      rlRun "ls -la /etc/fapolicyd/rules.d/"
+      rlAssertNotExists /etc/fapolicyd/fapolicyd.rules
+      rlAssertGreater "rules are deployed into /etc/fapolicyd/rules.d" $(ls -1 /etc/fapolicyd/rules.d | wc -w) 0
+    rlPhaseEnd; }
+
     rlPhaseStartTest "rules order" && {
       CleanupRegister --mark 'rlRun "rm -f /etc/fapolicyd/rules.d/5{1,2,3}-custom.rules"'
       rlRun "echo 'allow perm=open exe=/path/to/binary1 : all' > /etc/fapolicyd/rules.d/52-custom.rules"

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -77,9 +77,13 @@ EOF
       V_old=1.0.4
       R_old=1.fc35
     }
-    rlIsRHELLike '>=8' && {
+    rlIsRHEL '>=8' || rlIsRHELLike '>=8' && {
       V_old=1.0.2
       R_old=6.el8
+    }
+    rlIsRHEL '>=9' || rlIsRHELLike '>=9' && {
+      V_old=1.0.3
+      R_old=4.el9
     }
     while read -r NULL N NULL NULL A; do
       rlRpmDownload $N $V_old $R_old $A

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -38,6 +38,8 @@ rlJournalStart && {
     CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
     CleanupRegister 'rlRun "popd"'
     rlRun "pushd $TmpDir"
+    CleanupRegister --mark "rlRun 'RpmSnapshotRevert'; rlRun 'RpmSnapshotDiscard'"
+    rlRun "RpmSnapshotCreate"
     CleanupRegister 'rlRun "fapCleanup"'
     rlRun "fapSetup"
     rlRun "rlFetchSrcForInstalled fapolicyd"
@@ -65,9 +67,6 @@ index c0ab31c..9103e12 100644
 +allow perm=any all : all
 EOF
     rlRun -s "rpmbuild -bb -D 'dist $(rpmbuild -E '%dist')_99' ~/rpmbuild/SPECS/fapolicyd.spec"
-    CleanupRegister --mark "rlRun 'RpmSnapshotRevert'; rlRun 'RpmSnapshotDiscard'"
-    rlRun "RpmSnapshotCreate"
-    #rlRun "RpmSnapshotRevert"
     rlRun "mkdir rpms"
     pushd rpms
     rlRun "cp $(grep 'Wrote:' $rlRun_LOG | cut -d ' ' -f 2 | tr '\n' ' ') $(grep 'Wrote:' $rlRun_LOG1 | cut -d ' ' -f 2 | tr '\n' ' ') ./"

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Dalibor Pospisil <dapospis@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2021 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="fapolicyd"
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+    tcfRun "rlCheckMakefileRequires" || rlDie "cannot continue"
+    rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
+    CleanupRegister 'rlRun "popd"'
+    rlRun "pushd $TmpDir"
+    CleanupRegister 'rlRun "fapCleanup"'
+    rlRun "fapSetup"
+    rlRun "rlFetchSrcForInstalled fapolicyd"
+    rlRun "rpm -ivh ./fapolicyd*.src.rpm"
+    rlRun "yum-builddep -y ~/rpmbuild/SPECS/fapolicyd.spec"
+    rlRun -s "rpmbuild -bb -D 'dist _99' ~/rpmbuild/SPECS/fapolicyd.spec"
+    CleanupRegister --mark "rlRun 'RpmSnapshotRevert'; rlRun 'RpmSnapshotDiscard'"
+    rlRun "RpmSnapshotCreate"
+    #rlRun "RpmSnapshotRevert"
+    rlRun "mkdir rpms"
+    pushd rpms
+    rlRun "cp $(grep 'Wrote:' $rlRun_LOG | cut -d ' ' -f 2 | tr '\n' ' ') ./"
+    IFS=' ' read -r SRC N V R A < <(rpm -q --qf '%{sourcerpm} %{name} %{version} %{release} %{arch}\n' fapolicyd)
+    V_new="$V"
+    R_new="${R}_99"
+    rlIsFedora && {
+      V_old=1.0.4
+      R_old=1.fc35
+    }
+    rlIsRHELLike '>=8.6' && {
+      V_old=1.0.2
+      R_old=6.el8
+    }
+    while read -r NULL N NULL NULL A; do
+      rlRpmDownload $N $V_old $R_old $A
+    done < <(rpm -qa --qf '%{sourcerpm} %{name} %{version} %{release} %{arch}\n' | grep "^$SRC ")
+    rlRun "createrepo --database ./"
+    rlRun "ls -la"
+    popd
+    which dnf &>/dev/null && _dnfc=dnf\ || _dnfc=yum-
+    rlRun "${_dnfc}config-manager --add-repo file://$PWD/rpms"
+    repofile=$(grep -l "file://$PWD/rpms" /etc/yum.repos.d/*.repo)
+    CleanupRegister "rlRun 'rm -f $repofile'"
+    rlRun "echo -e 'sslverify=0\ngpgcheck=0\nskip_if_unavailable=1' >> $repofile"
+  rlPhaseEnd; }
+
+  tcfTry "Tests" --no-assert && {
+    rlPhaseStartTest "rules order" && {
+      CleanupRegister --mark 'rlRun "rm -f /etc/fapolicyd/rules.d/5{1,2,3}-custom.rules"'
+      rlRun "echo 'allow perm=open exe=/path/to/binary1 : all' > /etc/fapolicyd/rules.d/52-custom.rules"
+      rlRun "echo 'allow perm=open exe=/path/to/binary2 : all' > /etc/fapolicyd/rules.d/51-custom.rules"
+      rlRun "echo 'allow perm=open exe=/path/to/binary3 : all' > /etc/fapolicyd/rules.d/53-custom.rules"
+      rlRun "fagenrules"
+      rlRun "cat /etc/fapolicyd/compiled.rules"
+      rlRun "cat /etc/fapolicyd/compiled.rules | tr '\n' ' ' | grep -q 'binary2.*binary1.*binary3'" 0 "check correct order"
+      CleanupDo --mark
+    rlPhaseEnd; }
+    
+    rlPhaseStartTest "upgrade from old version - default rules" && {
+      CleanupRegister --mark "rlRun 'RpmSnapshotRevert'"
+      rlRun "rm -rf /etc/fapolicyd"
+      rlRun "yum install fapolicyd-$V_old-$R_old -y --allowerasing"
+      rlRun "ls -la /etc/fapolicyd/"
+      rlRun "yum install fapolicyd-$V-$R -y --allowerasing"
+      rlRun "ls -la /etc/fapolicyd/"
+      rlRun "ls -la /etc/fapolicyd/rules.d/"
+      rlAssertNotExists /etc/fapolicyd/fapolicyd.rules
+      rlAssertGreater "rules are deployed into /etc/fapolicyd/rules.d" $(ls -1 /etc/fapolicyd/rules.d | wc -w) 0
+      CleanupDo --mark
+    rlPhaseEnd; }
+    
+    rlPhaseStartTest "upgrade from old version - changed rules" && {
+      CleanupRegister --mark "rlRun 'RpmSnapshotRevert'"
+      rlRun "rm -rf /etc/fapolicyd"
+      rlRun "yum install fapolicyd-$V_old-$R_old -y --allowerasing"
+      echo "allow perm=any all : all" >> /etc/fapolicyd/fapolicyd.rules
+      rlRun "ls -la /etc/fapolicyd/"
+      rlRun "yum install fapolicyd-$V-$R -y --allowerasing"
+      rlRun "ls -la /etc/fapolicyd/"
+      rlRun "ls -la /etc/fapolicyd/rules.d/"
+      rlAssertExists /etc/fapolicyd/fapolicyd.rules
+      rlAssertEquals "rules are deployed into /etc/fapolicyd/rules.d" $(ls -1 /etc/fapolicyd/rules.d | wc -w) 0
+      CleanupDo --mark
+    rlPhaseEnd; }
+    
+    false && rlPhaseStartTest "upgrade - fapolicyd.rules exists" && {
+      CleanupRegister --mark "rlRun 'RpmSnapshotRevert'"
+      cat > /etc/fapolicyd/fapolicyd.rules <<EOF
+%languages=application/x-bytecode.ocaml,application/x-bytecode.python,application/java-archive,text/x-java,application/x-java-applet,application/javascript,text/javascript,text/x-awk,text/x-gawk,text/x-lisp,application/x-elc,text/x-lua,text/x-m4,text/x-nftables,text/x-perl,text/x-php,text/x-python,text/x-R,text/x-ruby,text/x-script.guile,text/x-tcl,text/x-luatex,text/x-systemtap
+deny_audit perm=any pattern=ld_so : all
+allow perm=any uid=0 : dir=/var/tmp/
+allow perm=any uid=0 trust=1 : all
+allow perm=open exe=/usr/bin/rpm : all
+allow perm=open exe=/usr/bin/python3.10 comm=dnf : all
+deny_audit perm=any all : ftype=application/x-bad-elf
+allow perm=open all : ftype=application/x-sharedlib trust=1
+deny_audit perm=open all : ftype=application/x-sharedlib
+allow perm=any exe=/my/special/rule : trust=1
+allow perm=execute all : trust=1
+allow perm=open all : ftype=%languages trust=1
+deny_audit perm=any all : ftype=%languages
+allow perm=any all : ftype=text/x-shellscript
+deny_audit perm=execute all : all
+allow perm=open all : all
+EOF
+      rlRun "yum update -y fapolicyd"
+      rlRun "ls -la /etc/fapolicyd/rules.d"
+      rlRun "ls -la /etc/fapolicyd/fapolicyd.rules"
+      #rlRun "sed -ri 's///' ~/rpmbuild/SPECS/fapolicyd.spec"
+      CleanupDo --mark
+    rlPhaseEnd; }
+  
+    false && rlPhaseStartTest "precedence of fapolicyd.rules" && {
+      CleanupRegister --mark 'rlRun "rm -f /etc/fapolicyd/fapolicyd.rules"'
+      cat > /etc/fapolicyd/fapolicyd.rules <<EOF
+%languages=application/x-bytecode.ocaml,application/x-bytecode.python,application/java-archive,text/x-java,application/x-java-applet,application/javascript,text/javascript,text/x-awk,text/x-gawk,text/x-lisp,application/x-elc,text/x-lua,text/x-m4,text/x-nftables,text/x-perl,text/x-php,text/x-python,text/x-R,text/x-ruby,text/x-script.guile,text/x-tcl,text/x-luatex,text/x-systemtap
+deny_audit perm=any pattern=ld_so : all
+allow perm=any uid=0 : dir=/var/tmp/
+allow perm=any uid=0 trust=1 : all
+allow perm=open exe=/usr/bin/rpm : all
+allow perm=open exe=/usr/bin/python3.10 comm=dnf : all
+deny_audit perm=any all : ftype=application/x-bad-elf
+allow perm=open all : ftype=application/x-sharedlib trust=1
+deny_audit perm=open all : ftype=application/x-sharedlib
+allow perm=any exe=/my/special/rule : trust=1
+allow perm=execute all : trust=1
+allow perm=open all : ftype=%languages trust=1
+deny_audit perm=any all : ftype=%languages
+allow perm=any all : ftype=text/x-shellscript
+deny_audit perm=execute all : all
+allow perm=open all : all
+EOF
+      rlRun "fapStart"
+      rlRun "fapStop"
+      rlRun -s "fapServiceOut"
+      rlAssertGrep "/my/special/rule" $rlRun_LOG
+      CleanupDo --mark
+    rlPhaseEnd; }
+    :
+  tcfFin; }
+
+  rlPhaseStartCleanup && {
+    CleanupDo
+    tcfCheckFinal
+  rlPhaseEnd; }
+  rlJournalPrintText
+rlJournalEnd; }

--- a/fapolicyd/Sanity/rules-d/runtest.sh
+++ b/fapolicyd/Sanity/rules-d/runtest.sh
@@ -85,9 +85,16 @@ EOF
       V_old=1.0.3
       R_old=4.el9
     }
-    while read -r NULL N NULL NULL A; do
-      rlRpmDownload $N $V_old $R_old $A
-    done < <(rpm -qa --qf '%{sourcerpm} %{name} %{version} %{release} %{arch}\n' | grep "^$SRC ")
+    packages=(
+      fapolicyd-${V_old}-${R_old}.$A
+      fapolicyd-debuginfo-${V_old}-${R_old}.$A
+      fapolicyd-debugsource-${V_old}-${R_old}.$A
+      fapolicyd-dnf-plugin-${V_old}-${R_old}.noarch
+      fapolicyd-selinux-${V_old}-${R_old}.noarch
+    )
+    for package in "${packages[@]}"; do
+      rlRpmDownload $package
+    done
     rlRun "createrepo --database ./"
     rlRun "ls -la"
     popd
@@ -95,6 +102,7 @@ EOF
     rlRun "${_dnfc}config-manager --add-repo file://$PWD/rpms"
     repofile=$(grep -l "file://$PWD/rpms" /etc/yum.repos.d/*.repo)
     CleanupRegister "rlRun 'rm -f $repofile'"
+    rlRun "yum clean all"
     rlRun "echo -e 'sslverify=0\ngpgcheck=0\nskip_if_unavailable=1' >> $repofile"
   rlPhaseEnd; }
 

--- a/fapolicyd/Sanity/sets/runtest.sh
+++ b/fapolicyd/Sanity/sets/runtest.sh
@@ -42,6 +42,10 @@ rlJournalStart
         rlRun "pushd $TmpDir"
         CleanupRegister 'rlRun "fapCleanup"'
         rlRun "fapSetup"
+        [[ -e /etc/fapolicyd/rules.d ]] && {
+          rlRun "mv /etc/fapolicyd/compiled.rules /etc/fapolicyd/fapolicyd.rules"
+          rlRun "rm -f /etc/fapolicyd/rules.d/*"
+        }
         echo 'int main(void) { return 0; }' > main.c
         exe1="exe1"
         exe2="exe2"

--- a/fapolicyd/Sanity/trust-db/runtest.sh
+++ b/fapolicyd/Sanity/trust-db/runtest.sh
@@ -62,6 +62,10 @@ rlJournalStart && {
     rlRun "pushd $TmpDir"
     CleanupRegister 'rlRun "fapCleanup"'
     rlRun "fapSetup"
+    [[ -e /etc/fapolicyd/rules.d ]] && {
+      rlRun "mv /etc/fapolicyd/compiled.rules /etc/fapolicyd/fapolicyd.rules"
+      rlRun "rm -f /etc/fapolicyd/rules.d/*"
+    }
     CleanupRegister "rlFileRestore"
     rlRun "rlFileBackup --clean /opt/testdir/ /opt/testfile"
     rlRun "mkdir -p '/opt/testdir/subdir'"


### PR DESCRIPTION
on
- [x] Fedora
- [x] RHEL

ACs
- [x] rules.d is populated for a clean install
- [x] rules.d is not populated if fapolicyd.rules exists and is modified (non-default)
- [x] rules.d is populated and fapolicyd.rules is removed if it was not modified (default)
- [x] fapolicyd service does not start (throws an error) if rules.d is populated and fapolicyd.rules exists
- [x] rules files in rules.d concatenated into the final rules policy in a sorted way based on the filename
- [x] unchanged (default) rules.d does not get updated on `yum update`
- [x] modified default rules.d does not get updated on `yum update`
- [x] with a custom rules file, the unchanged (default) rules.d does not get updated on `yum update`