### PR TITLE
Catalogue installation adaptations

### DIFF
--- a/tang/Sanity/tang-operator/reg_test/key_management_test/minimal-keyretrieve-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/tang/Sanity/tang-operator/reg_test/key_management_test/minimal-keyretrieve-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: {{OPERATOR_NAMESPACE}}

--- a/tang/Sanity/tang-operator/reg_test/key_management_test/minimal-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/tang/Sanity/tang-operator/reg_test/key_management_test/minimal-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: {{OPERATOR_NAMESPACE}}

--- a/tang/Sanity/tang-operator/reg_test/key_management_test/multiple-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/tang/Sanity/tang-operator/reg_test/key_management_test/multiple-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: {{OPERATOR_NAMESPACE}}


### PR DESCRIPTION
This issue allows parameterizing more stuff on tang operator tests:
1 - operator installation/removal test can be disabled
2 - operator installation namespace can be specified externally
Example of both options:
OPERATOR_NAMESPACE=openshift-operators DISABLE_BUNDLE_INSTALL_TESTS=1 make

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>