### PR TITLE
Fix certificate chain test

### DIFF
--- a/rsyslog/Multihost/bz1174345-RFE-Support-relp-with-tls/runtest.sh
+++ b/rsyslog/Multihost/bz1174345-RFE-Support-relp-with-tls/runtest.sh
@@ -102,7 +102,7 @@ expiration_days = 365
 dns_name = "$CLIENTS"
 ip_address = "$CLIENT_IP"
 email = "root@$CLIENTS"
-tls_www_server
+tls_www_client
 EOF
         cat client.tmpl
         rlRun "certtool --generate-privkey --outfile client-key.pem --bits 2048" 0 "Generate key for client"

--- a/rsyslog/Multihost/relp/runtest.sh
+++ b/rsyslog/Multihost/relp/runtest.sh
@@ -125,7 +125,7 @@ expiration_days = 365
 dns_name = "$syncCLIENT_HOSTNAME"
 ip_address = "$syncCLIENT_IP"
 email = "root@$syncCLIENT_HOSTNAME"
-tls_www_server
+tls_www_client
 EOF
         cat client.tmpl
         rlRun "certtool --generate-privkey --outfile client-key.pem --bits 2048" 0 "Generate key for client"

--- a/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
+++ b/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
@@ -54,7 +54,7 @@ unit = "GSS"
 locality = "Brno"
 state = "Moravia"
 country = CZ
-cn = "rsyslog+gnutls"
+cn = "rsyslog+chain+caroot"
 serial = 001
 expiration_days = 365
 dns_name = "$(hostname)"
@@ -74,7 +74,7 @@ unit = "GSS"
 locality = "Brno"
 state = "Moravia"
 country = CZ
-cn = "rsyslog+gnutls"
+cn = "rsyslog+chain+ca"
 serial = 001
 expiration_days = 365
 dns_name = "$(hostname)"
@@ -95,7 +95,7 @@ unit = "GSS"
 locality = "Brno"
 state = "Moravia"
 country = CZ
-cn = "rsyslog+gnutls"
+cn = "rsyslog+chain+server"
 serial = 002
 expiration_days = 365
 dns_name = "$(hostname)"
@@ -114,13 +114,13 @@ unit = "GSS"
 locality = "Brno"
 state = "Moravia"
 country = CZ
-cn = "rsyslog+gnutls"
+cn = "rsyslog+chain+client"
 serial = 002
 expiration_days = 365
 dns_name = "$(hostname)"
 ip_address = "127.0.0.1"
 email = "root@$(hostname)"
-tls_www_server
+tls_www_client
 EOF
     cat client.tmpl
     rlRun "certtool --generate-privkey --outfile client-key.pem --bits 2048" 0 "Generate key for client"

--- a/rsyslog/Regression/bz1880434-gnutls-shutdown/runtest.sh
+++ b/rsyslog/Regression/bz1880434-gnutls-shutdown/runtest.sh
@@ -96,7 +96,7 @@ expiration_days = 365
 dns_name = "$(hostname)"
 ip_address = "127.0.0.1"
 email = "root@$(hostname)"
-tls_www_server
+tls_www_client
 EOF
     cat client.tmpl
     rlRun "certtool --generate-privkey --outfile client-key.pem --bits 2048" 0 "Generate key for client"


### PR DESCRIPTION
tls_www_client profile must be included so that
client certificate is not rejected with error
"err 26:unsupported certificate purpose"
Additionally, cn is modified to identify the certificate or CA,
so that when issues take place the CN shows quickly error origin

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>