### PR TITLE
rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in: Add new SSL certificate chain configuration option

### DIFF
--- a/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/main.fmf
+++ b/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/main.fmf
@@ -8,6 +8,7 @@ require+:
   - library(distribution/dpcommon)
   - rsyslog
   - /usr/bin/certtool
+  - openssl
 duration: 5m
 enabled: true
 /gnutls:
@@ -34,20 +35,38 @@ enabled: true
       - enabled: false
         when: distro ~< rhel-7.8
         continue: false
+    id: 16a60e3f-09ec-40ce-bc70-7803b21e0a74
 /openssl:
-    require+:
-      - rsyslog-openssl
-    environment:
-        driver: ossl
-    extra-summary: driver=ossl /CoreOS/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in
+  require+:
+    - rsyslog-openssl
+  environment:
+      driver: ossl
+  tier: '2'
+  tag:
+    - Tier2
+  /concatenation:
     link:
       - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2026346
-    tag:
-      - Tier2
+    tag+:
       - rhel-8.5
-    tier: '2'
     adjust:
       - enabled: false
         when: distro < rhel-8.5
         continue: false
     extra-nitrate: TC#0613026
+    id: d270ef68-fd90-41e6-9e60-8d38b0386dc9
+  /extraCA:
+    environment+:
+        extraCA: true
+    link:
+      - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2124934
+      - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2124849
+    tag+:
+      - rhel-9.2
+      - rhel-8.8
+    adjust:
+      - enabled: false
+        when: distro ~< rhel-8, rhel-8.8, rhel-9.2
+        continue: false
+    extra-nitrate: TC#0614622
+    id: 8fd38e04-0aae-48b9-b68c-dfb34e583ebf

--- a/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
+++ b/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
@@ -173,6 +173,7 @@ global(
     DefaultNetstreamDriverCAFile="/etc/rsyslogd.d/ca-cert.pem"
     DefaultNetstreamDriverCertFile="/etc/rsyslogd.d/server-cert.pem"
     DefaultNetstreamDriverKeyFile="/etc/rsyslogd.d/server-key.pem"
+    #EXTRACA
 )
 EOF
       rlRun "rsyslogServerPrintEffectiveConfig -n"
@@ -192,8 +193,14 @@ EOF
       rlRun "rsyslogServiceStop"
       rlRun "rsyslogServerStop"
       rlRun "> $rsyslogServerLogDir/messages"
-      rlRun "cat server-cert.pem ca-cert.pem ca2-cert.pem > /etc/rsyslogd.d/server-cert.pem"
-      rlRun "chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d"
+      if [[ "${extraCA,,}" == "true" ]];
+      then
+        # Enable Extra CA Files (only for SSL)
+        rlRun "sed -i 's|#EXTRACA|NetstreamDriverCAExtraFiles=\"/etc/rsyslogd.d/ca2-cert.pem\"|' $rsyslogServerConf"
+      else
+        rlRun "cat server-cert.pem ca-cert.pem ca2-cert.pem > /etc/rsyslogd.d/server-cert.pem"
+        rlRun "chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d"
+      fi
       rlRun "rsyslogServerStart"
       rlRun "rsyslogServiceStart"
       rlRun "rsyslogServerPrintEffectiveConfig -n"

--- a/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
+++ b/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
@@ -185,6 +185,7 @@ EOF
 
   tcfTry "Tests" --no-assert && {
     rlPhaseStartTest && {
+      rlRun "echo 'ahoj' | openssl s_client -CAfile ca-root-cert.pem -port 6514"
       rlRun "logger 'test message'"
       rlRun "sleep 3s"
       rlAssertNotGrep 'test message' $rsyslogServerLogDir/messages
@@ -195,6 +196,8 @@ EOF
       rlRun "chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d"
       rlRun "rsyslogServerStart"
       rlRun "rsyslogServiceStart"
+      rlRun "rsyslogServerPrintEffectiveConfig -n"
+      rlRun "echo 'ahoj' | openssl s_client -CAfile ca-root-cert.pem -port 6514"
       rlRun "logger 'test message'"
       rlRun "sleep 3s"
       rlAssertGrep 'test message' $rsyslogServerLogDir/messages

--- a/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
+++ b/rsyslog/Regression/bz1627799-RFE-Support-Intermediate-Certificate-Chains-in/runtest.sh
@@ -108,25 +108,6 @@ EOF
     rlRun "certtool --generate-request --template server.tmpl --load-privkey server-key.pem --outfile server-request.pem" 0 "Generate server cert request"
     rlRun "certtool --generate-certificate --template server.tmpl --load-request server-request.pem  --outfile server-cert.pem --load-ca-certificate ca-cert.pem --load-ca-privkey ca-key.pem" 0 "Generate server cert"
 
-    cat > client.tmpl <<EOF
-organization = "Red Hat"
-unit = "GSS"
-locality = "Brno"
-state = "Moravia"
-country = CZ
-cn = "rsyslog+chain+client"
-serial = 002
-expiration_days = 365
-dns_name = "$(hostname)"
-ip_address = "127.0.0.1"
-email = "root@$(hostname)"
-tls_www_client
-EOF
-    cat client.tmpl
-    rlRun "certtool --generate-privkey --outfile client-key.pem --bits 2048" 0 "Generate key for client"
-    rlRun "certtool --generate-request --template client.tmpl --load-privkey client-key.pem --outfile client-request.pem" 0 "Generate client cert request"
-    rlRun "certtool --generate-certificate --template client.tmpl --load-request client-request.pem  --outfile client-cert.pem --load-ca-certificate ca-cert.pem --load-ca-privkey ca-key.pem" 0 "Generate client cert"
-
     rlRun "mkdir -p /etc/rsyslogd.d && chmod 700 /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
     rlRun "cp *.pem /etc/rsyslogd.d/"
     rlRun "chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d"
@@ -138,8 +119,6 @@ EOF
 global(
     DefaultNetstreamDriver="$driver"
     DefaultNetstreamDriverCAFile="/etc/rsyslogd.d/ca-root-cert.pem"
-    DefaultNetstreamDriverCertFile="/etc/rsyslogd.d/client-cert.pem"
-    DefaultNetstreamDriverKeyFile="/etc/rsyslogd.d/client-key.pem"
 )
 EOF
 
@@ -161,8 +140,7 @@ EOF
       rsyslogServerConfigAppend "MODULES" <<EOF
 module(
     load="imtcp"
-    StreamDriver.AuthMode="x509/name"
-    PermittedPeer="$(hostname)"
+    StreamDriver.AuthMode="anon"
     StreamDriver.Mode="1"
     StreamDriver.Name="$driver"
 )


### PR DESCRIPTION
This change permits using newly created configuration
value, "NetstreamDriverCAExtraFiles", that enable
the usage of additiona CA File (required for SSL
certificate chains)

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>