### PR TITLE
/etc/grub.d is not part of s390x installation

### DIFF
--- a/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/runtest.sh
+++ b/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/runtest.sh
@@ -86,6 +86,7 @@ rlJournalStart
                 -e '/etc/xinetd.conf' \
                 -e '/etc/xinetd.d' \
                 -e '/etc/securetty' \
+                -e '/etc/grub.d' \
             > aide_config_paths_2" \
             0 "Sanitaze aide config paths - remove paths that are not part of 'repoquery -al'"
 

--- a/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/runtest.sh
+++ b/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/runtest.sh
@@ -86,9 +86,11 @@ rlJournalStart
                 -e '/etc/xinetd.conf' \
                 -e '/etc/xinetd.d' \
                 -e '/etc/securetty' \
-                -e '/etc/grub.d' \
             > aide_config_paths_2" \
             0 "Sanitaze aide config paths - remove paths that are not part of 'repoquery -al'"
+
+        [[ $(rlGetArch) =~ "s390" ]] && rlRun "sed -i '\|/etc/grub.d|d' aide_config_paths_2" 0 \
+            "Removing /etc/grub.d aide configured path: not present on s390x"
 
         rlRun "mv aide_config_paths_2 aide_config_paths"
         rlRun "wc -l aide_config_paths" 0 "Count of paths in aide config"


### PR DESCRIPTION
Fixing test. This line of aide.conf is not check against filesystem because it is not present on s390x anymore.