### PR TITLE
usbguard/Sanity/1738590-rebase: Make journalctl output unit independent

### DIFF
--- a/usbguard/Sanity/1738590-rebase-usbguard-to-0.7.8/runtest.sh
+++ b/usbguard/Sanity/1738590-rebase-usbguard-to-0.7.8/runtest.sh
@@ -120,7 +120,7 @@ rlJournalStart
         t=$(date +"%F %T")
         rlRun "rlServiceStart usbguard" 1-255
         rlRun "sleep 1s"
-        rlRun -s "journalctl -u usbguard -a --no-pager -S \"$t\""
+        rlRun -s "journalctl -a --no-pager -S \"$t\""
         rlAssertGrep "Permissions for.*should be 0600" $rlRun_LOG
         rm -f $rlRun_LOG
         rlRun "systemctl reset-failed usbguard"
@@ -129,7 +129,7 @@ rlJournalStart
         t=$(date +"%F %T")
         rlRun "rlServiceStart usbguard"
         rlRun "sleep 10s"
-        rlRun -s "journalctl -u usbguard -a --no-pager -S \"$t\""
+        rlRun -s "journalctl -a --no-pager -S \"$t\""
 #        rlAssertGrep "Permissions for.*should be 0600" $rlRun_LOG
         rm -f $rlRun_LOG
         rlRun -s "usbguard list-rules"
@@ -153,7 +153,7 @@ rlJournalStart
         rlRun "sleep 2s"
         rlRun "systemctl -l --no-pager status usbguard"
         rlRun "usbguard list-devices"
-        rlRun -s "journalctl -u usbguard -l --since '$since' --no-pager"
+        rlRun -s "journalctl -l --since '$since' --no-pager"
         rlAssertNotGrep "code=dumped" $rlRun_LOG
         rlAssertNotGrep "code=killed" $rlRun_LOG
         rm -f $rlRun_LOG
@@ -164,7 +164,7 @@ rlJournalStart
         rlRun "sleep 2s"
         rlRun "systemctl -l --no-pager status usbguard"
         rlRun "usbguard list-devices"
-        rlRun -s "journalctl -u usbguard -l --since '$since' --no-pager"
+        rlRun -s "journalctl -l --since '$since' --no-pager"
         rlAssertNotGrep "code=dumped" $rlRun_LOG
         rlAssertNotGrep "code=killed" $rlRun_LOG
         rm -f $rlRun_LOG
@@ -175,7 +175,7 @@ rlJournalStart
         rlRun "sleep 2s"
         rlRun "systemctl -l --no-pager status usbguard"
         rlRun "usbguard list-devices"
-        rlRun -s "journalctl -u usbguard -l --since '$since' --no-pager"
+        rlRun -s "journalctl -l --since '$since' --no-pager"
         rlAssertNotGrep "code=dumped" $rlRun_LOG
         rlAssertNotGrep "code=killed" $rlRun_LOG
         rm -f $rlRun_LOG
@@ -186,7 +186,7 @@ rlJournalStart
         rlRun "sleep 2s"
         rlRun "systemctl -l --no-pager status usbguard"
         rlRun "usbguard list-devices"
-        rlRun -s "journalctl -u usbguard -l --since '$since' --no-pager"
+        rlRun -s "journalctl -l --since '$since' --no-pager"
         rlAssertNotGrep "code=dumped" $rlRun_LOG
         rlAssertNotGrep "code=killed" $rlRun_LOG
         rm -f $rlRun_LOG


### PR DESCRIPTION
Since 8.8/9.2 usbguard does not produce warning/error/debug related messages to the standard output, instead everything is forwarded to syslog. We turned off logging to console, to avoid duplicate messages.
``` journalctl -u usbguard -a --no-pager --since $date ``` shows messages from the usbguard systemd unit. However, messages are now transported via syslog, so those are not attached to the mentioned systemd unit. Thus, no message will be shown in the output. Instead we should use ```journalctl -a --no-pager --since $date ```

**Message coming from syslog**
```
Wed 2023-01-11 03:42:21.142924 EST [s=629b4e1adf164f129a0628878c0f1f13;i=3af;b=6abd5fa9b76d4d5f9dd8c8d6ac8885fa;m=37363f45;t=5f1f8fa8ae5bc;x=7b5e18ba6f403eb9]
    _BOOT_ID=6abd5fa9b76d4d5f9dd8c8d6ac8885fa
    _MACHINE_ID=591c9b6345eb4154b60dad2966123028
    SYSLOG_FACILITY=3
    _UID=0
    _GID=0
    _TRANSPORT=syslog
    _HOSTNAME=ci-vm-10-0-139-80.hosted.upshift.rdu2.redhat.com
    SYSLOG_IDENTIFIER=usbguard-daemon
    _COMM=usbguard-daemon
    _CAP_EFFECTIVE=20000009
    _SELINUX_CONTEXT=system_u:system_r:usbguard_t:s0
    PRIORITY=3
    MESSAGE=Permissions for /etc/usbguard/rules.d/asd.conf should be 0600
    SYSLOG_PID=24578
    _PID=24578
    _SOURCE_REALTIME_TIMESTAMP=1673426541142924
```

**Message coming from usbguard systemd unit**
```
Wed 2023-01-11 03:42:21.145009 EST [s=629b4e1adf164f129a0628878c0f1f13;i=3b3;b=6abd5fa9b76d4d5f9dd8c8d6ac8885fa;m=37365107;t=5f1f8fa8af77e;x=58b9b7728659c22c]
    _BOOT_ID=6abd5fa9b76d4d5f9dd8c8d6ac8885fa
    _MACHINE_ID=591c9b6345eb4154b60dad2966123028
    PRIORITY=5
    SYSLOG_FACILITY=3
    SYSLOG_IDENTIFIER=systemd
    _UID=0
    _GID=0
    _TRANSPORT=journal
    _PID=1
    _COMM=systemd
    _EXE=/usr/lib/systemd/systemd
    _CMDLINE=/usr/lib/systemd/systemd --switched-root --system --deserialize 17
    _CAP_EFFECTIVE=1ffffffffff
    _SELINUX_CONTEXT=system_u:system_r:init_t:s0
    _SYSTEMD_CGROUP=/init.scope
    _SYSTEMD_UNIT=init.scope
    _SYSTEMD_SLICE=-.slice
    _HOSTNAME=ci-vm-10-0-139-80.hosted.upshift.rdu2.redhat.com
    UNIT=usbguard.service
    CODE_FILE=../src/core/service.c
    CODE_LINE=3392
    CODE_FUNC=service_sigchld_event
    MESSAGE=usbguard.service: Control process exited, code=exited status=1
    INVOCATION_ID=eb7e28b0052548a98d8c6ec7725f4b17
    _SOURCE_REALTIME_TIMESTAMP=1673426541145009
```