### PR TITLE
Changing link meaning from 'relates' to 'verifies'

### DIFF
--- a/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
+++ b/aide/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
@@ -15,8 +15,8 @@ tag:
 - Tier2
 tier: '2'
 link:
--   relates: https://bugzilla.redhat.com/show_bug.cgi?id=1957654
--   relates: https://bugzilla.redhat.com/show_bug.cgi?id=1957656
+-   verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1957654
+-   verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1957656
 adjust:
 -   enabled: false
     when: distro < rhel-9

--- a/clevis/Sanity/clevis-luks-askpass-enabled/main.fmf
+++ b/clevis/Sanity/clevis-luks-askpass-enabled/main.fmf
@@ -8,8 +8,8 @@ tag:
   - Tier1
 tier: '1'
 link:
-  - relates: https://bugzilla.redhat.com/show_bug.cgi?id=2107078
-  - relates: https://bugzilla.redhat.com/show_bug.cgi?id=2107081
+  - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2107078
+  - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2107081
 adjust:
   - enabled: false
     when: distro < rhel-8.6

--- a/clevis/Sanity/kernel-keyring-support/main.fmf
+++ b/clevis/Sanity/kernel-keyring-support/main.fmf
@@ -4,7 +4,7 @@ description: Test clevis to check parameter that allows reading a LUKS2 token id
     associated to that token id
 enabled: true
 link:
-  - relates: https://bugzilla.redhat.com/show_bug.cgi?id=2126533
+  - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2126533
 tag:
   - CI-Tier-1
   - Tier1

--- a/clevis/Sanity/sha256-thp/main.fmf
+++ b/clevis/Sanity/sha256-thp/main.fmf
@@ -12,7 +12,7 @@ tag:
   - Tier1
   - CI-Tier-1
 link:
-  - relates: https://bugzilla.redhat.com/show_bug.cgi?id=1956760
+  - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1956760
 adjust:
   - enabled: false
     when: distro < rhel-9

--- a/tang/Sanity/sha256-thp/main.fmf
+++ b/tang/Sanity/sha256-thp/main.fmf
@@ -13,7 +13,7 @@ tag:
 - Tier2
 tier: '2'
 link:
--   relates: https://bugzilla.redhat.com/show_bug.cgi?id=1956765
+-   verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1956765
 adjust:
 -   enabled: false
     when: distro < rhel-9


### PR DESCRIPTION
The 'relates' was not correct. Tests verifies linked bugzillas.