### PR TITLE
Different format of log message for fedora-systems

### DIFF
--- a/clevis/Sanity/simple-bind-luks/runtest.sh
+++ b/clevis/Sanity/simple-bind-luks/runtest.sh
@@ -87,7 +87,11 @@ rlJournalStart
 
         rlRun "packageVersion=$(rpm -q ${PACKAGE} --qf '%{name}-%{version}-%{release}\n')"
         if rlTestVersion "${packageVersion}" '>=' 'clevis-15-8'; then
-            rlAssertGrep "Error communicating with the server http://localhost" $rlRun_LOG
+            if rlIsRHEL; then
+		rlAssertGrep "Error communicating with the server http://localhost" $rlRun_LOG
+            else
+		rlAssertGrep "Error communicating with server http://localhost" $rlRun_LOG
+            fi
         else
             rlAssertGrep "Error communicating with the server!" $rlRun_LOG
         fi


### PR DESCRIPTION
For fedora system is different format of message than in Rhel's. Add conditional to grep it properly for each type of system.