### PR TITLE
Remove tag RHEL8_SP_wanted for one rsyslog test

### DIFF
--- a/rsyslog/Regression/bz886004-rsyslog-not-understaning-rfc5424-messages-through/main.fmf
+++ b/rsyslog/Regression/bz886004-rsyslog-not-understaning-rfc5424-messages-through/main.fmf
@@ -14,7 +14,6 @@ recommend:
 duration: 5m
 enabled: true
 tag:
-- RHEL8_SP_wanted
 - SP-TBU
 - TIPpass
 - TIPpass_Security


### PR DESCRIPTION
rsyslog/Regression/bz886004-rsyslog-not-understaning-rfc5424-messages-through

* Removing RHEL8_SP_wanted tag - the test works on RHEL-8 and RHEL-9
* The tag was removed also in TCMS