### PR TITLE
rsyslog/Sanity/pid-source: do not execute for < 9.3

### DIFF
--- a/rsyslog/Sanity/pid-source/main.fmf
+++ b/rsyslog/Sanity/pid-source/main.fmf
@@ -12,8 +12,12 @@ tag:
 tier: '2'
 adjust:
   - enabled: false
-    when: distro < rhel-8
+    when: distro < rhel-8.9
     continue: false
+  - enabled: false
+    when: distro ~< rhel-9.3
+    continue: false
+
 link:
   - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2176397
   - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2176398


### PR DESCRIPTION
Do not execute for < 9.3 as the fix was introduced later, see https://dashboard.osci.redhat.com/#/artifact/brew-build/aid/54471104?focus=baseos-ci.brew-build.tier1.functional