### PR TITLE
Include README.md for tang operator test suite

### DIFF
--- a/tang-operator/README.md
+++ b/tang-operator/README.md
@@ -1,0 +1,7 @@
+# tang-operator Test Suite
+
+:exclamation::exclamation::exclamation: IMPORTANT NOTE :exclamation::exclamation::exclamation:\
+tang-operator upstream Test Suite has been moved to next repository:\
+https://github.com/RedHat-SP-Security/tang-operator-tests
+
+Please, avoid commits regarding tang-operator test suite to this repository and commit to the previous one.


### PR DESCRIPTION
tang-operator test suite has been moved. Include
README.md to indicate it, as well as where the
new repository is located.