### PR TITLE
rsyslog/Regression/bz1419228: increase timeout

### DIFF
--- a/rsyslog/Regression/bz1419228-rsyslog-imjournal-module-no-longer-receives-logs/main.fmf
+++ b/rsyslog/Regression/bz1419228-rsyslog-imjournal-module-no-longer-receives-logs/main.fmf
@@ -8,7 +8,7 @@ require+:
 - library(distribution/ConditionalPhases)
 recommend:
 - rsyslog
-duration: 5m
+duration: 10m
 enabled: true
 tag:
 - CI-Tier-1


### PR DESCRIPTION
Increase timeout because this test might need more time to finish its tasks. Otherwise we will see false positive test failure.
See https://artifacts.dev.testing-farm.io/d12c85f7-7571-47ff-a5e1-82c7879fcafc/
