### PR TITLE
/librdkafka/Sanity/consumer-producer: Initial test

### DIFF
--- a/librdkafka/Sanity/consumer-producer/Makefile
+++ b/librdkafka/Sanity/consumer-producer/Makefile
@@ -1,0 +1,12 @@
+CC=gcc
+NAME=kafka-prog
+FLAGS=$(shell pkg-config --cflags rdkafka)
+LIBS=$(shell pkg-config --libs rdkafka)
+
+all: $(NAME)
+
+$(NAME): $(NAME).c
+	gcc $(NAME).c -I/usr/include/librdkafka $(FLAGS) -o $(NAME) $(LIBS)
+
+clean:
+	rm -rf $(NAME)

--- a/librdkafka/Sanity/consumer-producer/kafka-prog.c
+++ b/librdkafka/Sanity/consumer-producer/kafka-prog.c
@@ -1,0 +1,209 @@
+#include <assert.h>
+#include <ctype.h>
+#include <getopt.h>
+#include <rdkafka.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+
+#define BUFFERSIZE 512
+static volatile sig_atomic_t run = 1;
+enum kafka_mode_t { MODE_UNSPECIFIED, MODE_CONSUMER, MODE_PRODUCER };
+
+static void stop(int sig) {
+  run = 0;
+  fclose(stdin);
+}
+
+static void logger(const rd_kafka_t* rk, int level, const char* fac,
+                   const char* buf) {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  fprintf(stderr, "%u.%03u RDKAFKA-%i-%s: %s: %s\n", (int)tv.tv_sec,
+          (int)(tv.tv_usec / 1000), level, fac, rk ? rd_kafka_name(rk) : NULL,
+          buf);
+}
+
+static void usage(char* prog_name) {
+  printf(
+      "Usage:\n"
+      "%s consumer <broker> <group.id> <topic1> <topic2>..\n"
+      "%s producer <broker> <topic>\n",
+      prog_name, prog_name);
+}
+
+int main(int argc, char** argv) {
+  char buffer[BUFFERSIZE];
+  enum kafka_mode_t mode = MODE_UNSPECIFIED;
+  const char* topic = NULL;
+  char** topics = NULL;
+  const char* brokers = NULL;
+  const char* groupid = NULL;
+  int topic_cnt;
+
+  rd_kafka_t* rk;
+  rd_kafka_conf_t* conf;
+  rd_kafka_resp_err_t err;
+
+  if (argc > 1 && strcmp(argv[1], "consumer") == 0) {
+    mode = MODE_CONSUMER;
+    brokers = argv[2];
+    groupid = argv[3];
+    topics = &argv[4];
+    topic_cnt = argc - 4;
+  } else if (argc > 1 && strcmp(argv[1], "producer") == 0) {
+    mode = MODE_PRODUCER;
+    brokers = argv[2];
+    topic = argv[3];
+  } else {
+    usage(argv[0]);
+    exit(1);
+  }
+
+  conf = rd_kafka_conf_new();
+  // rd_kafka_conf_set_log_cb(conf, logger);
+
+  if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, buffer,
+                        sizeof(buffer)) != RD_KAFKA_CONF_OK) {
+    fprintf(stderr, "%s\n", buffer);
+    exit(1);
+  }
+
+  signal(SIGINT, stop);
+
+  if (mode == MODE_PRODUCER) {
+    fprintf(stderr, "Starting producer\n");
+    assert(brokers != NULL && topic != NULL);
+
+    if (rd_kafka_conf_set(conf, "client.id", "TestID", buffer,
+                          sizeof(buffer)) != RD_KAFKA_CONF_OK) {
+      fprintf(stderr, "%s\n", buffer);
+      exit(1);
+    }
+
+    //  rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
+
+    if (!(rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, buffer, sizeof(buffer)))) {
+      fprintf(stderr, "Failed to create new producer: %s\n", buffer);
+      exit(1);
+    }
+
+    const int controllerID = rd_kafka_controllerid(rk, 10 * 1000);
+    printf("Producer: rd_kafka_controllerid='%d'\n", controllerID);
+
+    while (run && fgets(buffer, sizeof(buffer), stdin)) {
+      size_t len = strlen(buffer);
+
+      if (buffer[len - 1] == '\n') buffer[--len] = '\0';
+
+      if (len == 0) {
+        rd_kafka_poll(rk, 0 /*non-blocking */);
+        continue;
+      }
+    retry:
+      err = rd_kafka_producev(rk, RD_KAFKA_V_TOPIC(topic),
+                              RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                              RD_KAFKA_V_VALUE(buffer, len),
+                              RD_KAFKA_V_OPAQUE(NULL), RD_KAFKA_V_END);
+
+      if (err) {
+        fprintf(stderr, "Failed to produce to topic %s: %d\n", topic,
+                rd_kafka_err2str(err));
+
+        if (err == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+          rd_kafka_poll(rk, 1000 /*block for max 1000ms*/);
+          goto retry;
+        }
+      } else {
+        fprintf(stderr,
+                "Enqueued message (%zd bytes) "
+                "for topic: %s\n",
+                len, topic);
+      }
+
+      rd_kafka_poll(rk, 0 /*non-blocking*/);
+    }
+    fprintf(stderr, "Flushing final messages..\n");
+    rd_kafka_flush(rk, 10 * 1000);
+
+    if (rd_kafka_outq_len(rk) > 0)
+      fprintf(stderr, "%d message(s) were not delivered\n",
+              rd_kafka_outq_len(rk));
+
+  } else if (mode == MODE_CONSUMER) {
+    rd_kafka_topic_partition_list_t* subscription;
+
+    // consumer - client
+    fprintf(stderr, "Starting consumer brokers=%s, groupdid=%s, topics=%s\n",
+            brokers, groupid, topics[0]);
+    assert(brokers != NULL && groupid != NULL && topics != 0);
+
+    if (rd_kafka_conf_set(conf, "group.id", groupid, buffer, sizeof(buffer)) !=
+        RD_KAFKA_CONF_OK) {
+      fprintf(stderr, "%s\n", buffer);
+      rd_kafka_conf_destroy(conf);
+      return 1;
+    }
+
+    rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, buffer, sizeof(buffer));
+    if (!rk) {
+      fprintf(stderr, "%% Failed to create new consumer: %s\n", buffer);
+      return 1;
+    }
+    conf = NULL;
+    rd_kafka_poll_set_consumer(rk);
+    subscription = rd_kafka_topic_partition_list_new(topic_cnt);
+    for (int i = 0; i < topic_cnt; i++) {
+      rd_kafka_topic_partition_list_add(subscription, topics[i],
+                                        RD_KAFKA_PARTITION_UA);
+    }
+    err = rd_kafka_subscribe(rk, subscription);
+    if (err) {
+      fprintf(stderr, "%% Failed to subscribe to %d topics: %s\n",
+              subscription->cnt, rd_kafka_err2str(err));
+      rd_kafka_topic_partition_list_destroy(subscription);
+      rd_kafka_destroy(rk);
+      return 1;
+    }
+
+    rd_kafka_topic_partition_list_destroy(subscription);
+    const int controllerID = rd_kafka_controllerid(rk, 10 * 1000);
+    printf("Consumer: rd_kafka_controllerid='%d'\n", controllerID);
+    while (run) {
+      rd_kafka_message_t* rkm;
+
+      rkm = rd_kafka_consumer_poll(rk, 100);
+      if (!rkm) continue;
+
+      if (rkm->err) {
+        fprintf(stderr, "%% Consumer error: %s\n",
+                rd_kafka_message_errstr(rkm));
+        rd_kafka_message_destroy(rkm);
+        continue;
+      }
+
+      printf("There was a proper message\n");
+      printf("On %s [%" PRId32 "] at offset %" PRId64 "\n",
+             rd_kafka_topic_name(rkm->rkt), rkm->partition, rkm->offset);
+
+      printf(" Value: %.*s\n", (int)rkm->len,
+             rkm->payload ? (const char*)rkm->payload : "NULL");
+      fflush(stdout);
+
+      rd_kafka_message_destroy(rkm);
+    }
+
+    printf("Closing consumer\n");
+    rd_kafka_consumer_close(rk);
+  }
+
+  fflush(stdin);
+
+  rd_kafka_destroy(rk);
+  return 0;
+}

--- a/librdkafka/Sanity/consumer-producer/main.fmf
+++ b/librdkafka/Sanity/consumer-producer/main.fmf
@@ -1,0 +1,23 @@
+summary: sanity test for rdkafka library
+description: 'Librdkafka consumer producer test'
+contact: Attila Lakatos <alakatos@redhat.com>
+duration: 10m
+test: ./runtest.sh
+require:
+- library(distribution/dpcommon)
+- library(selinux-policy/common)
+recommend:
+- librdkafka
+- librdkafka-devel
+- java-1.8.0-openjdk
+enabled: true
+extra-summary:
+extra-task:
+extra-nitrate:
+adjust:
+-   enabled: false
+    when: distro < rhel-8.10
+#    continue: false
+# -   enabled: false
+#     when: arch == s390x
+#     continue: false

--- a/librdkafka/Sanity/consumer-producer/main.fmf
+++ b/librdkafka/Sanity/consumer-producer/main.fmf
@@ -6,9 +6,9 @@ test: ./runtest.sh
 require:
 - library(distribution/dpcommon)
 - library(selinux-policy/common)
-recommend:
 - librdkafka
 - librdkafka-devel
+recommend:
 - java-1.8.0-openjdk
 enabled: true
 extra-summary:

--- a/librdkafka/Sanity/consumer-producer/main.fmf
+++ b/librdkafka/Sanity/consumer-producer/main.fmf
@@ -11,9 +11,6 @@ require:
 recommend:
 - java-1.8.0-openjdk
 enabled: true
-extra-summary:
-extra-task:
-extra-nitrate:
 adjust:
 -   enabled: false
     when: distro < rhel-8.10
@@ -21,3 +18,5 @@ adjust:
 # -   enabled: false
 #     when: arch == s390x
 #     continue: false
+extra-nitrate: TC#0615946
+id: c00b3a65-4ce3-4f6e-af11-8f9c1e316a3b

--- a/librdkafka/Sanity/consumer-producer/runtest.sh
+++ b/librdkafka/Sanity/consumer-producer/runtest.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/librdkafka/Sanity/consumer-producer
+#   Description: sanity test for rdkafka library
+#   Author: Attila Lakatos <alakatos@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2023 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+# . /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="rsyslog"
+CONTROLLERID=123
+
+# This test focuses on creating a producer-consumer environment and estabilishing
+# exactly one consumer(server) and one producer(client). First, the producer will
+# start generating messages, which will be then processed/received by the consumer.
+# The test checks if all messages have arrived successfully and if the rd_kafka_controllerid
+# symbol is available in the dynamically linked shared object library and if it works as expected.
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+    tcfRun "rlCheckMakefileRequires"
+    CleanupRegister 'rlRun "rlSEPortRestore"'
+
+    rlRun "rlSEPortAdd tcp 9092 syslogd_port_t"
+    rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
+    CleanupRegister 'rlRun "popd"'
+    rlRun "ls -al"
+    rlRun "cp Makefile kafka-prog.c $TmpDir"
+    rlRun "pushd $TmpDir"
+    CleanupRegister 'rlRun "rlFileRestore"'
+    rlRun "rlFileBackup --clean /var/log/imkafka.log /tmp/kafka-logs /tmp/zookeeper"
+    rlRun "rm -rf /tmp/kafka-logs /tmp/zookeeper"
+
+    rlRun "rlDownload kafka_2.11-2.1.0.tgz http://download.eng.bos.redhat.com/qa/rhts/lookaside/kafka_2.11-2.1.0.tgz"
+    rlRun "tar -xzf kafka_2.11-2.1.0.tgz"
+    rlRun "cd kafka_2.11-2.1.0"
+    rlRun "bin/zookeeper-server-start.sh config/zookeeper.properties &"
+    CleanupRegister "rlRun 'kill $!' 0 'kill zookeeper server'; rlWaitForSocket --close 2181"
+    rlWaitForSocket 2181
+    rlRun "sleep 3"
+
+    rlRun "sed -i -E 's/^(broker\.id=)[0-9]+$/\1$CONTROLLERID/' config/server.properties"
+    rlRun "head -30 config/server.properties"
+    rlRun "bin/kafka-server-start.sh config/server.properties &"
+    CleanupRegister "rlRun 'kill $!' 0 'kill kafka server'; rlWaitForSocket --close 9092"
+    rlWaitForSocket 9092
+    rlRun "sleep 10"
+
+    rlRun "bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic TestTopic" 0-255
+    rlRun "bin/kafka-topics.sh --list --zookeeper localhost:2181"
+    CleanupRegister "rlRun 'make clean'"
+    rlRun "cp ../Makefile ../kafka-prog.c ."
+    rlRun "make"
+
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Pre-test" && {
+    rlRun "nm -D /usr/lib64/librdkafka.so | grep rd_kafka_controllerid" 0 "The rd_kafka_controllerid symbol must be present in the shared object library"
+  rlPhaseEnd; }
+
+  tcfTry "Tests" --no-assert && {
+    rlPhaseStartTest && {
+      rlRun "./kafka-prog consumer 127.0.0.1:9092 TestGroupID TestTopic > /tmp/kafka-consumer.log 2>&1 &"
+      CleanupRegister "rlRun 'kill -SIGINT $!' 0 'kill kafka consumer'"
+      CleanupRegister "rlRun 'rm -f /tmp/kafka-consumer.log' "
+      sleep 3
+
+      ITER=20
+      for i in `seq $ITER`; do
+        echo "Testing producer-consumer scenario $i" >> /tmp/kafka-producer-input.log
+      done
+      rlRun "cat /tmp/kafka-producer-input.log"
+
+      rlRun "./kafka-prog producer 127.0.0.1:9092 TestTopic < /tmp/kafka-producer-input.log > /tmp/kafka-producer.log 2>&1 &"
+      CleanupRegister "rlRun 'kill -SIGINT $!' 0-1 'kill kafka producer'"
+      CleanupRegister "rlRun 'rm -f /tmp/kafka-producer.log /tmp/kafka-producer-input.log' "
+
+
+      sleep 10
+      rlRun "cat /tmp/kafka-consumer.log"
+      rlRun "cat /tmp/kafka-producer.log"
+      for i in `seq $ITER`; do
+        rlAssertGrep "Value: Testing producer-consumer scenario $i" /tmp/kafka-consumer.log
+      done
+      rlAssertGrep "Consumer: rd_kafka_controllerid='$CONTROLLERID'" /tmp/kafka-consumer.log
+      rlAssertGrep "Producer: rd_kafka_controllerid='$CONTROLLERID'" /tmp/kafka-producer.log
+
+    rlPhaseEnd; }
+  tcfFin; }
+
+  rlPhaseStartCleanup && {
+    CleanupDo
+    tcfCheckFinal
+  rlPhaseEnd; }
+  rlJournalPrintText
+rlJournalEnd; }

--- a/librdkafka/Sanity/consumer-producer/runtest.sh
+++ b/librdkafka/Sanity/consumer-producer/runtest.sh
@@ -53,7 +53,7 @@ rlJournalStart && {
     rlRun "cp Makefile kafka-prog.c $TmpDir"
     rlRun "pushd $TmpDir"
     CleanupRegister 'rlRun "rlFileRestore"'
-    rlRun "rlFileBackup --clean /var/log/imkafka.log /tmp/kafka-logs /tmp/zookeeper"
+    rlRun "rlFileBackup --clean /tmp/kafka-logs /tmp/zookeeper"
     rlRun "rm -rf /tmp/kafka-logs /tmp/zookeeper"
 
     rlRun "rlDownload kafka_2.11-2.1.0.tgz http://download.eng.bos.redhat.com/qa/rhts/lookaside/kafka_2.11-2.1.0.tgz"
@@ -99,9 +99,8 @@ rlJournalStart && {
       rlRun "./kafka-prog producer 127.0.0.1:9092 TestTopic < /tmp/kafka-producer-input.log > /tmp/kafka-producer.log 2>&1 &"
       CleanupRegister "rlRun 'kill -SIGINT $!' 0-1 'kill kafka producer'"
       CleanupRegister "rlRun 'rm -f /tmp/kafka-producer.log /tmp/kafka-producer-input.log' "
-
-
       sleep 10
+
       rlRun "cat /tmp/kafka-consumer.log"
       rlRun "cat /tmp/kafka-producer.log"
       for i in `seq $ITER`; do

--- a/librdkafka/Sanity/consumer-producer/runtest.sh
+++ b/librdkafka/Sanity/consumer-producer/runtest.sh
@@ -56,7 +56,7 @@ rlJournalStart && {
     rlRun "rlFileBackup --clean /tmp/kafka-logs /tmp/zookeeper"
     rlRun "rm -rf /tmp/kafka-logs /tmp/zookeeper"
 
-    rlRun "rlDownload kafka_2.11-2.1.0.tgz http://download.eng.bos.redhat.com/qa/rhts/lookaside/kafka_2.11-2.1.0.tgz"
+    rlRun "rlDownload kafka_2.11-2.1.0.tgz https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz"
     rlRun "tar -xzf kafka_2.11-2.1.0.tgz"
     rlRun "cd kafka_2.11-2.1.0"
     rlRun "bin/zookeeper-server-start.sh config/zookeeper.properties &"


### PR DESCRIPTION
 This test focuses on creating a producer-consumer environment and establishing exactly one consumer(server) and one producer(client). First, the producer will  start generating messages, which will be then processed/received by the consumer.  The test checks if all messages have arrived successfully and if the `rd_kafka_controllerid` symbol is available in the dynamically linked shared object library and if it works as expected.

The C program simply serves as either a consumer or a producer. Can be executed in both directions.